### PR TITLE
Optional timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! ```no_run
 //! // To avoid timing out, or limit the request's response time even more,
 //! // use .with_timeout(n) before .send(). The given value is in seconds.
-//! // NOTE: The default timeout is 5 seconds.
+//! // NOTE: There is no timeout by default.
 //! if let Ok(response) = minreq::post("http://httpbin.org/delay/6")
 //!     .with_timeout(10)
 //!     .send()
@@ -63,8 +63,7 @@
 //! ```
 //!
 //! # Timeouts
-//! The timeout of the created request is 5 seconds by default. You
-//! can change this in two ways:
+//! By default, a request has no timeout.  You can change this in two ways:
 //! - Use this function (`create_request`) and call
 //!   [`with_timeout`](struct.Request.html#method.with_timeout)
 //!   on it to set the timeout per-request like so:


### PR DESCRIPTION
 Make timeout optional

In the previous design, a timeout was always set on the TcpStream.
This commit changes the Connection's timeout field from a u64 to a
Option<u64> and only sets a read and write timeout if the timeout
field is Some(s).