### PR TITLE
Upgrade to rust 2018 and fix lint warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["http", "https", "client", "request"]
 categories = ["web-programming::http-client"]
 license = "ISC"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "neonmoe/minreq", branch = "1.0.3" }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,7 +2,7 @@ use std::io::{BufReader, BufWriter, Error, ErrorKind, Read, Write};
 use std::net::TcpStream;
 use std::time::Duration;
 use std::env;
-use http::{Request, Response};
+use crate::{Request, Response};
 #[cfg(feature = "https")]
 use std::sync::Arc;
 #[cfg(feature = "https")]

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::Lines;
 use std::io::Error;
-use connection::Connection;
+use crate::connection::Connection;
 
 /// A URL type for requests.
 pub type URL = String;
@@ -36,17 +36,17 @@ impl fmt::Display for Method {
     /// Formats the Method to the form in the HTTP request,
     /// ie. Method::Get -> "GET", Method::Post -> "POST", etc.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &Method::Get => write!(f, "GET"),
-            &Method::Head => write!(f, "HEAD"),
-            &Method::Post => write!(f, "POST"),
-            &Method::Put => write!(f, "PUT"),
-            &Method::Delete => write!(f, "DELETE"),
-            &Method::Connect => write!(f, "CONNECT"),
-            &Method::Options => write!(f, "OPTIONS"),
-            &Method::Trace => write!(f, "TRACE"),
-            &Method::Patch => write!(f, "PATCH"),
-            &Method::Custom(ref s) => write!(f, "{}", s),
+        match *self {
+            Method::Get => write!(f, "GET"),
+            Method::Head => write!(f, "HEAD"),
+            Method::Post => write!(f, "POST"),
+            Method::Put => write!(f, "PUT"),
+            Method::Delete => write!(f, "DELETE"),
+            Method::Connect => write!(f, "CONNECT"),
+            Method::Options => write!(f, "OPTIONS"),
+            Method::Trace => write!(f, "TRACE"),
+            Method::Patch => write!(f, "PATCH"),
+            Method::Custom(ref s) => write!(f, "{}", s),
         }
     }
 }
@@ -137,7 +137,7 @@ impl Request {
         // Add the body
         http += "\r\n";
         if let Some(body) = self.body {
-            http += &format!("{}", body);
+            http += &body;
         }
         http
     }
@@ -185,19 +185,19 @@ fn parse_url(url: URL) -> (URL, URL, bool) {
         }
     }
     // Ensure the resource is *something*
-    if second.len() == 0 {
+    if second.is_empty() {
         second += "/";
     }
     // Set appropriate port
     let https = url.starts_with("https://");
-    if !first.contains(":") {
+    if !first.contains(':') {
         first += if https { ":443" } else { ":80" };
     }
     (first, second, https)
 }
 
 fn parse_status_line(line: &str) -> (i32, String) {
-    let mut split = line.split(" ");
+    let mut split = line.split(' ');
     if let Some(code) = split.nth(1) {
         if let Ok(code) = code.parse::<i32>() {
             if let Some(reason) = split.next() {
@@ -218,7 +218,7 @@ fn parse_http_response_content(lines: Lines) -> (HashMap<String, String>, String
             continue;
         }
         if writing_headers {
-            if let Some(index) = line.find(":") {
+            if let Some(index) = line.find(':') {
                 let key = line[..index].trim().to_string();
                 let value = line[index..].trim().to_string();
                 headers.insert(key, value);

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -1,4 +1,4 @@
-use http::{Method, Request, URL};
+use crate::{Method, Request, URL};
 
 /// Sends a request to `url` with `method`, returns the response or
 /// an [`Error`](https://doc.rust-lang.org/std/io/struct.Error.html).


### PR DESCRIPTION
* Upgrade to the rust 2018 edition
    - add edition to `Cargo.toml`
    - refactor module imports
* fix some clippy lint warnings