### PR TITLE
Reduce the number of `.clone()` in `.send()` and `.send_https()`

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -124,7 +124,7 @@ impl Request {
 
     /// Returns the HTTP request as a `String`, ready to be sent to
     /// the server.
-    pub(crate) fn into_string(self) -> String {
+    pub(crate) fn to_string(&self) -> String {
         let mut http = String::new();
         // Add the request line and the "Host" header
         http += &format!(
@@ -132,13 +132,13 @@ impl Request {
             self.method, self.resource, self.host
         );
         // Add other headers
-        for (k, v) in self.headers {
+        for (k, v) in &self.headers {
             http += &format!("{}: {}\r\n", k, v);
         }
         // Add the body
         http += "\r\n";
-        if let Some(body) = self.body {
-            http += &body;
+        if let &Some(ref body) = &self.body {
+            http += body;
         }
         http
     }


### PR DESCRIPTION
- I changed `create_tcp_stream()` to accept a parameter that
  implements `ToSocketAddrs` (instead of a `String`); we can now pass
  `&str` to that function.

- I modified and renamed (for consistency with other methods in the
  Rust standard library) `.into_string()` to `.to_string()`.  In this
  new implementation, `self` is borrowed rather than moved.

- In `.send()` and `.send_https()` I can now remove the clones of the
  hostname and just pass it by borrow to `create_tcp_stream()` and to
  Rustls's `try_from_ascii_str()`.