### PR TITLE
Serialize/deserialize JSON using Serde

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ script:
   - cargo test --features "https"
   - cargo test --release
   - cargo test --features "https" --release
+  - cargo test --features "json-using-serde"
+  - cargo test --features "json-using-serde" --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/minreq"
 homepage = "https://github.com/neonmoe/minreq"
 repository = "https://github.com/neonmoe/minreq"
 readme = "README.md"
-keywords = ["http", "https", "client", "request"]
+keywords = ["http", "https", "client", "request", "json"]
 categories = ["web-programming::http-client"]
 license = "ISC"
 edition = "2018"
@@ -20,11 +20,15 @@ maintenance = { status = "passively-maintained" }
 rustls = { version = "0.15", optional = true }
 webpki-roots = { version = "0.16", optional = true }
 webpki = { version = "0.19", optional = true }
+serde = { version = "1.0.60", optional = true }
+serde_json = { version = "1.0.40", optional = true }
 
 [dev-dependencies]
 tiny_http = "0.6"
+serde_derive = "1.0.60"
 
 [features]
 default = []
 
 https = ["rustls", "webpki-roots", "webpki"]
+json-using-serde = ["serde", "serde_json"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,17 +3,31 @@
 //! The library has a very minimal API, so you'll probably know
 //! everything you need to after reading a few examples.
 //!
-//! # HTTPS
+//! # Additional features
 //!
 //! Since the crate is supposed to be minimal in terms of
-//! dependencies, HTTPS is a feature on its own, as it requires the
-//! (very good) [`rustls`](https://crates.io/crates/rustls) crate. To
-//! be able to send HTTPS requests, you need to change your
-//! Cargo.toml's `[dependencies]` part to something like the
-//! following:
+//! dependencies, optional functionality can be enabled by specifying
+//! features for `minreq` dependency in `Cargo.toml`:
+//!
 //! ```toml
-//! minreq = { version = "*", features = ["https"] }
+//! [dependencies]
+//! minreq = { version = "*", features = ["https", "json-using-serde"] }
 //! ```
+//!
+//! Below is the list of all available features.
+//!
+//! ## `https`
+//!
+//! This feature uses the (very good) [`rustls`](https://crates.io/crates/rustls)
+//! crate to secure connection.
+//!
+//! ## `json-using-serde`
+//!
+//! This feature allows both serialize and deserialize JSON payload using
+//! [`serde_json`](https://crates.io/crates/serde_json) crate.
+//!
+//! `Request` and `Response` expose `with_json()` and `json()` respectively
+//! for converting struct to JSON and back.
 //!
 //! # Examples
 //!
@@ -92,6 +106,10 @@ extern crate rustls;
 extern crate webpki;
 #[cfg(feature = "https")]
 extern crate webpki_roots;
+#[cfg(feature = "json-using-serde")]
+extern crate serde;
+#[cfg(feature = "json-using-serde")]
+extern crate serde_json;
 
 mod connection;
 mod http;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,9 @@
 extern crate minreq;
 mod setup;
 
+#[cfg(feature = "json-using-serde")]
+use serde_derive::{Deserialize, Serialize};
+
 use self::setup::*;
 
 #[test]
@@ -11,6 +14,31 @@ fn test_https() {
         get_status_code(minreq::get("https://httpbin.org/status/418").send()),
         418
     );
+}
+
+#[cfg(feature = "json-using-serde")]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+struct Json<'a> {
+    str: &'a str,
+    num: u32,
+}
+
+#[test]
+#[cfg(feature = "json-using-serde")]
+fn test_json_using_serde() {
+    let original_json = Json {
+        str: "Json test",
+        num: 42,
+    };
+
+    let response = minreq::post(url("/echo"))
+        .with_json(&original_json)
+        .unwrap()
+        .send()
+        .unwrap();
+    let actual_json: Json = response.json().unwrap();
+
+    assert_eq!(&actual_json, &original_json);
 }
 
 #[test]

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -85,6 +85,10 @@ pub fn setup() {
                         request.respond(response).ok();
                     }
 
+                    &Method::Post if url == "/echo" => {
+                        request.respond(Response::from_string(content)).ok();
+                    }
+
                     &Method::Head if url == "/b" => {
                         request.respond(Response::empty(418)).ok();
                     }


### PR DESCRIPTION
JSON is a pretty common format nowadays and it's convenient to have
conversion handled by the library.

Following existing philosophy the functionality is exposed only when feature is enabled.