### PR TITLE
added wasm target support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minreq"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Jens Pitkanen <jens@neon.moe>"]
 description = "Simple, minimal-dependency HTTP client"
 documentation = "https://docs.rs/minreq"
@@ -17,21 +17,30 @@ travis-ci = { repository = "neonmoe/minreq" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
+serde = { version = "^1.0.101", optional = true }
+serde_json = { version = "^1.0.41", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustls = { version = "^0.16.0", optional = true }
 webpki-roots = { version = "^0.18.0", optional = true }
 webpki = { version = "^0.21.0", optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
-serde = { version = "^1.0.101", optional = true }
-serde_json = { version = "^1.0.41", optional = true }
 punycode = { version = "^0.4.1", optional = true }
 
-[dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = {version= "^0.3.33", features=["Request", "RequestInit", "RequestMode", "Headers", "Window", "Response", "ReadableStream"]}
+wasm-bindgen = "^0.2.56"
+wasm-bindgen-futures = "^0.4.6"
+futures = "^0.3.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tiny_http = "^0.6.2"
+
+[dev-dependencies]
 serde_derive = "^1.0.101"
 
 [features]
 default = []
-
 https = ["rustls", "webpki-roots", "webpki", "lazy_static"]
 json-using-serde = ["serde", "serde_json"]
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -3,6 +3,7 @@
 /// might want to handle with the `json-using-serde` feature. For
 /// that, check out examples/json.rs!
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() -> Result<(), minreq::Error> {
     let response = minreq::get("http://httpbin.org/anything")
         .with_body("Hello, world!")
@@ -10,4 +11,23 @@ fn main() -> Result<(), minreq::Error> {
     let hello = response.as_str()?;
     println!("{}", hello);
     Ok(())
+}
+
+/// See this example for wasm target:
+/// ```
+/// use wasm_bindgen::prelude::*;
+/// #[wasm_bindgen]
+/// pub async fn test() {
+///     let response = minreq::get("http://httpbin.org/anything")
+///         .with_body("Hello, world!")
+///         .send().await.unwrap();
+///     let hello = response.as_str().unwrap();
+///     println!("{}", hello);
+/// }
+/// ```
+/// 
+/// The example feature of cargo is not able to run this please ignore the following code.
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    panic!("can't use the cargo example feature for wasm target")
 }

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -1,6 +1,7 @@
 /// This example demonstrates probably the most complicated part of
 /// `minreq`. Useful when making loading bars, for example.
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() -> Result<(), minreq::Error> {
     let mut buffer = Vec::new();
     for byte in minreq::get("http://httpbin.org/get").send_lazy()? {
@@ -32,15 +33,32 @@ fn main() -> Result<(), minreq::Error> {
 }
 
 // Helper functions
-
+#[cfg(not(target_arch = "wasm32"))]
 fn flush() {
     use std::io::{stdout, Write};
     stdout().lock().flush().ok();
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn sleep() {
     use std::thread::sleep;
     use std::time::Duration;
 
     sleep(Duration::from_millis(5));
+}
+
+
+/// See this example for wasm target:
+/// ```
+/// use wasm_bindgen::prelude::*;
+/// #[wasm_bindgen]
+/// pub async fn test() {
+///     unimplemented!();
+/// }
+/// ```
+/// 
+/// The example feature of cargo is not able to run this please ignore the following code.
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    panic!("can't use the cargo example feature for wasm target")
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,10 +1,12 @@
 /// This example demonstrates the `json-using-serde` feature.
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(serde_derive::Deserialize)]
 struct Response {
     data: String,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() -> Result<(), minreq::Error> {
     let response = minreq::get("http://httpbin.org/anything")
         .with_body("Hello, world!")
@@ -12,4 +14,28 @@ fn main() -> Result<(), minreq::Error> {
     let json: Response = response.json()?;
     println!("{}", json.data);
     Ok(())
+}
+
+/// See this example for wasm target:
+/// ```
+/// #[derive(serde_derive::Deserialize)]
+/// struct Response {
+///     data: String,
+/// }
+///
+/// use wasm_bindgen::prelude::*;
+/// #[wasm_bindgen]
+/// pub async fn test() {
+///     let response = minreq::get("http://httpbin.org/anything")
+///         .with_body("Hello, world!")
+///         .send().await.unwrap();
+///     let json: Response = response.json()?;
+///     println!("{}", json.data);
+/// }
+/// ```
+/// 
+/// The example feature of cargo is not able to run this please ignore the following code.
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    panic!("can't use the cargo example feature for wasm target")
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,18 +1,90 @@
-use crate::{Error, Method, Request, ResponseLazy};
+use crate::{Error, Method, Request};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::ResponseLazy;
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(feature = "https")]
 use rustls::{self, ClientConfig, ClientSession, StreamOwned};
 use std::env;
+#[cfg(not(target_arch = "wasm32"))]
 use std::io::{self, BufReader, BufWriter, Read, Write};
+#[cfg(not(target_arch = "wasm32"))]
 use std::net::{TcpStream, ToSocketAddrs};
 #[cfg(feature = "https")]
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 #[cfg(feature = "https")]
+#[cfg(not(target_arch = "wasm32"))]
 use webpki::DNSNameRef;
 #[cfg(feature = "https")]
+#[cfg(not(target_arch = "wasm32"))]
 use webpki_roots::TLS_SERVER_ROOTS;
 
+#[cfg(target_arch = "wasm32")]
+const HEADERS_LIST: [&str; 58] = [
+    "Access-Control-Allow-Origin,",
+    "Access-Control-Allow-Credentials,",
+    "Access-Control-Expose-Headers,",
+    "Access-Control-Max-Age,",
+    "Access-Control-Allow-Methods,",
+    "Access-Control-Allow-Headers",
+    "Accept-Patch",
+    "Accept-Ranges",
+    "Age",
+    "Allow",
+    "Alt-Svc",
+    "Cache-Control",
+    "Connection",
+    "Content-Disposition",
+    "Content-Encoding",
+    "Content-Language",
+    "Content-Length",
+    "Content-Location",
+    "Content-MD5",
+    "Content-Range",
+    "Content-Type",
+    "Date",
+    "Delta-Base",
+    "ETag",
+    "Expires",
+    "IM",
+    "Last-Modified",
+    "Link",
+    "Location",
+    "P3P",
+    "Pragma",
+    "Proxy-Authenticate",
+    "Public-Key-Pins",
+    "Retry-After",
+    "Server",
+    "Set-Cookie",
+    "Strict-Transport-Security",
+    "Trailer",
+    "Transfer-Encoding",
+    "Tk",
+    "Upgrade",
+    "Vary",
+    "Via",
+    "Warning",
+    "WWW-Authenticate",
+    "Content-Security-Policy,",
+    "X-Content-Security-Policy,",
+    "X-WebKit-CSP",
+    "Refresh",
+    "Status",
+    "Timing-Allow-Origin",
+    "X-Content-Duration",
+    "X-Content-Type-Options",
+    "X-Powered-By",
+    "X-Request-ID,",
+    "X-Correlation-ID",
+    "X-UA-Compatible",
+    "X-XSS-Protection"
+];
+
 #[cfg(feature = "https")]
+#[cfg(not(target_arch = "wasm32"))]
 lazy_static::lazy_static! {
     static ref CONFIG: Arc<ClientConfig> = {
         let mut config = ClientConfig::new();
@@ -23,16 +95,20 @@ lazy_static::lazy_static! {
     };
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 type UnsecuredStream = BufReader<TcpStream>;
 #[cfg(feature = "https")]
+#[cfg(not(target_arch = "wasm32"))]
 type SecuredStream = StreamOwned<ClientSession, TcpStream>;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) enum HttpStream {
     Unsecured(UnsecuredStream),
     #[cfg(feature = "https")]
     Secured(Box<SecuredStream>),
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl HttpStream {
     fn create_unsecured(reader: UnsecuredStream) -> HttpStream {
         HttpStream::Unsecured(reader)
@@ -44,6 +120,7 @@ impl HttpStream {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Read for HttpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
@@ -78,6 +155,7 @@ impl Connection {
     /// Sends the [`Request`](struct.Request.html), consumes this
     /// connection, and returns a [`Response`](struct.Response.html).
     #[cfg(feature = "https")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn send_https(mut self) -> Result<ResponseLazy, Error> {
         self.request.host = ensure_ascii_host(self.request.host)?;
         let bytes = self.request.as_bytes();
@@ -106,6 +184,7 @@ impl Connection {
 
     /// Sends the [`Request`](struct.Request.html), consumes this
     /// connection, and returns a [`Response`](struct.Response.html).
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn send(mut self) -> Result<ResponseLazy, Error> {
         self.request.host = ensure_ascii_host(self.request.host)?;
         let bytes = self.request.as_bytes();
@@ -134,8 +213,131 @@ impl Connection {
         let response = ResponseLazy::from_stream(stream)?;
         handle_redirects(self, response)
     }
+
+    /// Sends the [`Request`](struct.Request.html), consumes this
+    /// connection, and returns a [`Response`](struct.Response.html).
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) async fn send(mut self) -> Result<crate::Response, Error> {
+        use wasm_bindgen::prelude::*;
+
+        #[wasm_bindgen]
+        extern "C" {
+            #[wasm_bindgen(js_namespace = console)]
+            fn log(s: &str);
+        }
+        macro_rules! println {
+            // Note that this is using the `log` function imported above during
+            // `bare_bones`
+            ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
+        }
+
+        use crate::Response;
+        use web_sys::{RequestInit};
+        use wasm_bindgen::{JsValue, JsCast};
+        use wasm_bindgen_futures::JsFuture;
+        use std::collections::HashMap;
+        type WebSysRequest = web_sys::Request;
+        type WebSysResponse = web_sys::Response;
+
+        self.request.host = ensure_ascii_host(self.request.host)?;
+
+        // set the method
+        let mut opts = RequestInit::new();
+        opts.method(match self.request.method {
+            Method::Get => "GET",
+            Method::Head => "HEAD",
+            Method::Post => "POST",
+            Method::Put => "PUT",
+            Method::Delete => "DELETE",
+            Method::Connect => "CONNECT",
+            Method::Options => "OPTIONS",
+            Method::Trace => "TRACE",
+            Method::Patch => "PATCH",
+            Method::Custom(ref s) => s,
+        });
+        
+        // set the body
+        if let Some(body) = &self.request.body {
+            opts.body(Some(&JsValue::from_str(&String::from_utf8_lossy(&body))));
+        }
+
+        // set the url
+        let request: WebSysRequest = match WebSysRequest::new_with_str_and_init(
+            &self.request.get_full_url(),
+            &opts,
+        ) {
+            Ok(request) => request,
+            Err(e) => {
+                println!("{:?}", e);
+                return Err(Error::Other("can't create request"))
+            },
+        };
+
+        // set the headers
+        for (header_name, header_value) in self.request.headers {
+            if let Err(e) = request.headers().set(&header_name, &header_value) {
+                println!("{:?}", e);
+                return Err(Error::Other("can't set header"))
+            }
+        }
+        
+        // send the request
+        let window = match web_sys::window() {
+            Some(window) => window,
+            None => return Err(Error::Other("program should be run in a browser (require a window)"))
+        };
+        let resp = match JsFuture::from(window.fetch_with_request(&request)).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                println!("{:?}", e);
+                return Err(Error::Other("can't send request"))
+            }
+        };
+
+        // get the response
+        if !resp.is_instance_of::<WebSysResponse>() {
+            return Err(Error::Other("can't convert response into a Response object"));
+        }
+        let resp: WebSysResponse = resp.dyn_into().unwrap();
+
+        // get the body
+        let mut bodyvec: Vec<u8> = Vec::new();
+        let body = JsFuture::from(match resp.text() {
+            Ok(body) => body,
+            Err(e) => {
+                println!("{:?}", e);
+                return Err(Error::Other("can't read response body"))
+            }
+        });
+        let body = match body.await {
+            Ok(body) => body,
+            Err(e) => {
+                println!("{:?}", e);
+                return Err(Error::Other("can't read response body (invalid utf8?)"))
+            }
+        };
+        let body = match body.as_string() {
+            Some(body) => body,
+            None => return Err(Error::Other("can't read response body. body is not a string or is invalid utf8"))
+        };
+        for byte in body.as_bytes() {
+            bodyvec.push(*byte);
+        }
+
+        // get headers
+        let headers = resp.headers();
+        let mut final_headers = HashMap::new();
+        for header in HEADERS_LIST.iter() {
+            if let Ok(Some(value)) = headers.get(header) {
+                final_headers.insert(header.to_string(), value);
+            }
+        }
+
+        Ok(Response::new(resp.status() as i32, resp.status_text(), final_headers, bodyvec))
+    }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn handle_redirects(connection: Connection, response: ResponseLazy) -> Result<ResponseLazy, Error> {
     let status_code = response.status_code;
     let url = response.headers.get("location");
@@ -146,6 +348,7 @@ fn handle_redirects(connection: Connection, response: ResponseLazy) -> Result<Re
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn get_redirect(
     connection: Connection,
     status_code: i32,
@@ -179,6 +382,7 @@ fn get_redirect(
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn create_tcp_stream<A>(host: A, timeout: Option<u64>) -> Result<TcpStream, std::io::Error>
 where
     A: ToSocketAddrs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,14 +157,17 @@
 #![deny(missing_docs)]
 
 #[cfg(feature = "https")]
+#[cfg(not(target_arch = "wasm32"))]
 extern crate rustls;
 #[cfg(feature = "json-using-serde")]
 extern crate serde;
 #[cfg(feature = "json-using-serde")]
 extern crate serde_json;
 #[cfg(feature = "https")]
+#[cfg(not(target_arch = "wasm32"))]
 extern crate webpki;
 #[cfg(feature = "https")]
+#[cfg(not(target_arch = "wasm32"))]
 extern crate webpki_roots;
 
 mod connection;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,162 +1,167 @@
 extern crate minreq;
 mod setup;
 
-#[cfg(feature = "json-using-serde")]
-use serde_derive::{Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
+mod tests_not_wasm {
+    #[cfg(feature = "json-using-serde")]
+    use serde_derive::{Deserialize, Serialize};
 
-use self::setup::*;
+    use self::super::setup::setup::*;
 
-#[test]
-#[cfg(feature = "https")]
-fn test_https() {
-    // TODO: Implement this locally.
-    assert_eq!(
-        get_status_code(minreq::get("https://httpbin.org/status/418").send()),
-        418
-    );
+    #[test]
+    #[cfg(feature = "https")]
+    fn test_https() {
+        // TODO: Implement this locally.
+        assert_eq!(
+            get_status_code(minreq::get("https://httpbin.org/status/418").send()),
+            418
+        );
+    }
+
+    #[cfg(feature = "json-using-serde")]
+    #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+    struct Json<'a> {
+        str: &'a str,
+        num: u32,
+    }
+
+    #[test]
+    #[cfg(feature = "json-using-serde")]
+    fn test_json_using_serde() {
+        let original_json = Json {
+            str: "Json test",
+            num: 42,
+        };
+
+        let response = minreq::post(url("/echo"))
+            .with_json(&original_json)
+            .unwrap()
+            .send()
+            .unwrap();
+        let actual_json: Json = response.json().unwrap();
+
+        assert_eq!(&actual_json, &original_json);
+    }
+
+    #[test]
+    fn test_latency() {
+        setup();
+        let body = get_body(
+            minreq::get(url("/slow_a"))
+                .with_body("Q".to_string())
+                .with_timeout(1)
+                .send(),
+        );
+        assert_ne!(body, "j: Q");
+    }
+
+    #[test]
+    fn test_headers() {
+        setup();
+        let body = get_body(
+            minreq::get(url("/header_pong"))
+                .with_header("Ping", "Qwerty")
+                .send(),
+        );
+        assert_eq!("Qwerty", body);
+    }
+
+    #[test]
+    fn test_custom_method() {
+        use minreq::Method;
+        setup();
+        let body = get_body(
+            minreq::Request::new(Method::Custom("GET".to_string()), url("/a"))
+                .with_body("Q")
+                .send(),
+        );
+        assert_eq!("j: Q", body);
+    }
+
+    #[test]
+    fn test_get() {
+        setup();
+        let body = get_body(minreq::get(url("/a")).with_body("Q").send());
+        assert_eq!(body, "j: Q");
+    }
+
+    #[test]
+    fn test_redirect_get() {
+        setup();
+        let body = get_body(minreq::get(url("/redirect")).with_body("Q").send());
+        assert_eq!(body, "j: Q");
+    }
+
+    #[test]
+    fn test_redirect_post() {
+        setup();
+        // POSTing to /redirect should return a 303, which means we should
+        // make a GET request to the given location. This test relies on
+        // the fact that the test server only responds to GET requests on
+        // the /a path.
+        let body = get_body(minreq::post(url("/redirect")).with_body("Q").send());
+        assert_eq!(body, "j: Q");
+    }
+
+    #[test]
+    fn test_infinite_redirect() {
+        setup();
+        let body = minreq::get(url("/infiniteredirect")).send();
+        assert!(body.is_err());
+    }
+
+    #[test]
+    fn test_head() {
+        setup();
+        assert_eq!(get_status_code(minreq::head(url("/b")).send()), 418);
+    }
+
+    #[test]
+    fn test_post() {
+        setup();
+        let body = get_body(minreq::post(url("/c")).with_body("E").send());
+        assert_eq!(body, "l: E");
+    }
+
+    #[test]
+    fn test_put() {
+        setup();
+        let body = get_body(minreq::put(url("/d")).with_body("R").send());
+        assert_eq!(body, "m: R");
+    }
+
+    #[test]
+    fn test_delete() {
+        setup();
+        assert_eq!(get_body(minreq::delete(url("/e")).send()), "n: ");
+    }
+
+    #[test]
+    fn test_trace() {
+        setup();
+        assert_eq!(get_body(minreq::trace(url("/f")).send()), "o: ");
+    }
+
+    #[test]
+    fn test_options() {
+        setup();
+        let body = get_body(minreq::options(url("/g")).with_body("U").send());
+        assert_eq!(body, "p: U");
+    }
+
+    #[test]
+    fn test_connect() {
+        setup();
+        let body = get_body(minreq::connect(url("/h")).with_body("I").send());
+        assert_eq!(body, "q: I");
+    }
+
+    #[test]
+    fn test_patch() {
+        setup();
+        let body = get_body(minreq::patch(url("/i")).with_body("O").send());
+        assert_eq!(body, "r: O");
+    }
+
 }
 
-#[cfg(feature = "json-using-serde")]
-#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
-struct Json<'a> {
-    str: &'a str,
-    num: u32,
-}
-
-#[test]
-#[cfg(feature = "json-using-serde")]
-fn test_json_using_serde() {
-    let original_json = Json {
-        str: "Json test",
-        num: 42,
-    };
-
-    let response = minreq::post(url("/echo"))
-        .with_json(&original_json)
-        .unwrap()
-        .send()
-        .unwrap();
-    let actual_json: Json = response.json().unwrap();
-
-    assert_eq!(&actual_json, &original_json);
-}
-
-#[test]
-fn test_latency() {
-    setup();
-    let body = get_body(
-        minreq::get(url("/slow_a"))
-            .with_body("Q".to_string())
-            .with_timeout(1)
-            .send(),
-    );
-    assert_ne!(body, "j: Q");
-}
-
-#[test]
-fn test_headers() {
-    setup();
-    let body = get_body(
-        minreq::get(url("/header_pong"))
-            .with_header("Ping", "Qwerty")
-            .send(),
-    );
-    assert_eq!("Qwerty", body);
-}
-
-#[test]
-fn test_custom_method() {
-    use minreq::Method;
-    setup();
-    let body = get_body(
-        minreq::Request::new(Method::Custom("GET".to_string()), url("/a"))
-            .with_body("Q")
-            .send(),
-    );
-    assert_eq!("j: Q", body);
-}
-
-#[test]
-fn test_get() {
-    setup();
-    let body = get_body(minreq::get(url("/a")).with_body("Q").send());
-    assert_eq!(body, "j: Q");
-}
-
-#[test]
-fn test_redirect_get() {
-    setup();
-    let body = get_body(minreq::get(url("/redirect")).with_body("Q").send());
-    assert_eq!(body, "j: Q");
-}
-
-#[test]
-fn test_redirect_post() {
-    setup();
-    // POSTing to /redirect should return a 303, which means we should
-    // make a GET request to the given location. This test relies on
-    // the fact that the test server only responds to GET requests on
-    // the /a path.
-    let body = get_body(minreq::post(url("/redirect")).with_body("Q").send());
-    assert_eq!(body, "j: Q");
-}
-
-#[test]
-fn test_infinite_redirect() {
-    setup();
-    let body = minreq::get(url("/infiniteredirect")).send();
-    assert!(body.is_err());
-}
-
-#[test]
-fn test_head() {
-    setup();
-    assert_eq!(get_status_code(minreq::head(url("/b")).send()), 418);
-}
-
-#[test]
-fn test_post() {
-    setup();
-    let body = get_body(minreq::post(url("/c")).with_body("E").send());
-    assert_eq!(body, "l: E");
-}
-
-#[test]
-fn test_put() {
-    setup();
-    let body = get_body(minreq::put(url("/d")).with_body("R").send());
-    assert_eq!(body, "m: R");
-}
-
-#[test]
-fn test_delete() {
-    setup();
-    assert_eq!(get_body(minreq::delete(url("/e")).send()), "n: ");
-}
-
-#[test]
-fn test_trace() {
-    setup();
-    assert_eq!(get_body(minreq::trace(url("/f")).send()), "o: ");
-}
-
-#[test]
-fn test_options() {
-    setup();
-    let body = get_body(minreq::options(url("/g")).with_body("U").send());
-    assert_eq!(body, "p: U");
-}
-
-#[test]
-fn test_connect() {
-    setup();
-    let body = get_body(minreq::connect(url("/h")).with_body("I").send());
-    assert_eq!(body, "q: I");
-}
-
-#[test]
-fn test_patch() {
-    setup();
-    let body = get_body(minreq::patch(url("/i")).with_body("O").send());
-    assert_eq!(body, "r: O");
-}

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -1,168 +1,171 @@
-extern crate minreq;
-extern crate tiny_http;
-use self::tiny_http::{Header, Method, Response, Server};
-use std::sync::Arc;
-use std::sync::Once;
-use std::thread;
-use std::time::Duration;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod setup {
+    extern crate minreq;
+    extern crate tiny_http;
+    use self::tiny_http::{Header, Method, Response, Server};
+    use std::sync::Arc;
+    use std::sync::Once;
+    use std::thread;
+    use std::time::Duration;
 
-static INIT: Once = Once::new();
+    static INIT: Once = Once::new();
 
-pub fn setup() {
-    INIT.call_once(|| {
-        let server = Arc::new(Server::http("localhost:35562").unwrap());
-        for _ in 0..4 {
-            let server = server.clone();
+    pub fn setup() {
+        INIT.call_once(|| {
+            let server = Arc::new(Server::http("localhost:35562").unwrap());
+            for _ in 0..4 {
+                let server = server.clone();
 
-            thread::spawn(move || loop {
-                let mut request = {
-                    if let Ok(request) = server.recv() {
-                        request
-                    } else {
-                        continue; // If .recv() fails, just try again.
-                    }
-                };
-                let mut content = String::new();
-                request.as_reader().read_to_string(&mut content).ok();
-                let headers = Vec::from(request.headers());
-
-                let url = String::from(request.url());
-                match request.method() {
-                    Method::Get if url == "/header_pong" => {
-                        for header in headers {
-                            if header.field.as_str() == "Ping" {
-                                let response = Response::from_string(format!("{}", header.value));
-                                request.respond(response).ok();
-                                return;
-                            }
+                thread::spawn(move || loop {
+                    let mut request = {
+                        if let Ok(request) = server.recv() {
+                            request
+                        } else {
+                            continue; // If .recv() fails, just try again.
                         }
-                        request.respond(Response::from_string("No header!")).ok();
-                    }
+                    };
+                    let mut content = String::new();
+                    request.as_reader().read_to_string(&mut content).ok();
+                    let headers = Vec::from(request.headers());
 
-                    Method::Get if url == "/slow_a" => {
-                        thread::sleep(Duration::from_secs(2));
-                        let response = Response::from_string(format!("j: {}", content));
-                        request.respond(response).ok();
-                    }
+                    let url = String::from(request.url());
+                    match request.method() {
+                        Method::Get if url == "/header_pong" => {
+                            for header in headers {
+                                if header.field.as_str() == "Ping" {
+                                    let response = Response::from_string(format!("{}", header.value));
+                                    request.respond(response).ok();
+                                    return;
+                                }
+                            }
+                            request.respond(Response::from_string("No header!")).ok();
+                        }
 
-                    Method::Get if url == "/a" => {
-                        let response = Response::from_string(format!("j: {}", content));
-                        request.respond(response).ok();
-                    }
-                    Method::Post if url == "/a" => {
-                        let response = Response::from_string("POST to /a is not valid.");
-                        request.respond(response).ok();
-                    }
+                        Method::Get if url == "/slow_a" => {
+                            thread::sleep(Duration::from_secs(2));
+                            let response = Response::from_string(format!("j: {}", content));
+                            request.respond(response).ok();
+                        }
 
-                    Method::Get if url == "/redirect" => {
-                        let response = Response::empty(301).with_header(
-                            Header::from_bytes(&b"Location"[..], &b"http://localhost:35562/a"[..])
+                        Method::Get if url == "/a" => {
+                            let response = Response::from_string(format!("j: {}", content));
+                            request.respond(response).ok();
+                        }
+                        Method::Post if url == "/a" => {
+                            let response = Response::from_string("POST to /a is not valid.");
+                            request.respond(response).ok();
+                        }
+
+                        Method::Get if url == "/redirect" => {
+                            let response = Response::empty(301).with_header(
+                                Header::from_bytes(&b"Location"[..], &b"http://localhost:35562/a"[..])
+                                    .unwrap(),
+                            );
+                            request.respond(response).ok();
+                        }
+                        Method::Post if url == "/redirect" => {
+                            let response = Response::empty(303).with_header(
+                                Header::from_bytes(&b"Location"[..], &b"http://localhost:35562/a"[..])
+                                    .unwrap(),
+                            );
+                            request.respond(response).ok();
+                        }
+
+                        Method::Get if url == "/infiniteredirect" => {
+                            let response = Response::empty(301).with_header(
+                                Header::from_bytes(
+                                    &b"Location"[..],
+                                    &b"http://localhost:35562/redirectpong"[..],
+                                )
                                 .unwrap(),
-                        );
-                        request.respond(response).ok();
-                    }
-                    Method::Post if url == "/redirect" => {
-                        let response = Response::empty(303).with_header(
-                            Header::from_bytes(&b"Location"[..], &b"http://localhost:35562/a"[..])
+                            );
+                            request.respond(response).ok();
+                        }
+                        Method::Get if url == "/redirectpong" => {
+                            let response = Response::empty(301).with_header(
+                                Header::from_bytes(
+                                    &b"Location"[..],
+                                    &b"http://localhost:35562/infiniteredirect"[..],
+                                )
                                 .unwrap(),
-                        );
-                        request.respond(response).ok();
-                    }
+                            );
+                            request.respond(response).ok();
+                        }
 
-                    Method::Get if url == "/infiniteredirect" => {
-                        let response = Response::empty(301).with_header(
-                            Header::from_bytes(
-                                &b"Location"[..],
-                                &b"http://localhost:35562/redirectpong"[..],
-                            )
-                            .unwrap(),
-                        );
-                        request.respond(response).ok();
-                    }
-                    Method::Get if url == "/redirectpong" => {
-                        let response = Response::empty(301).with_header(
-                            Header::from_bytes(
-                                &b"Location"[..],
-                                &b"http://localhost:35562/infiniteredirect"[..],
-                            )
-                            .unwrap(),
-                        );
-                        request.respond(response).ok();
-                    }
+                        Method::Post if url == "/echo" => {
+                            request.respond(Response::from_string(content)).ok();
+                        }
 
-                    Method::Post if url == "/echo" => {
-                        request.respond(Response::from_string(content)).ok();
-                    }
+                        Method::Head if url == "/b" => {
+                            request.respond(Response::empty(418)).ok();
+                        }
+                        Method::Post if url == "/c" => {
+                            let response = Response::from_string(format!("l: {}", content));
+                            request.respond(response).ok();
+                        }
+                        Method::Put if url == "/d" => {
+                            let response = Response::from_string(format!("m: {}", content));
+                            request.respond(response).ok();
+                        }
+                        Method::Delete if url == "/e" => {
+                            let response = Response::from_string(format!("n: {}", content));
+                            request.respond(response).ok();
+                        }
+                        Method::Trace if url == "/f" => {
+                            let response = Response::from_string(format!("o: {}", content));
+                            request.respond(response).ok();
+                        }
+                        Method::Options if url == "/g" => {
+                            let response = Response::from_string(format!("p: {}", content));
+                            request.respond(response).ok();
+                        }
+                        Method::Connect if url == "/h" => {
+                            let response = Response::from_string(format!("q: {}", content));
+                            request.respond(response).ok();
+                        }
+                        Method::Patch if url == "/i" => {
+                            let response = Response::from_string(format!("r: {}", content));
+                            request.respond(response).ok();
+                        }
 
-                    Method::Head if url == "/b" => {
-                        request.respond(Response::empty(418)).ok();
+                        _ => {
+                            request
+                                .respond(Response::from_string("Not Found").with_status_code(404))
+                                .ok();
+                        }
                     }
-                    Method::Post if url == "/c" => {
-                        let response = Response::from_string(format!("l: {}", content));
-                        request.respond(response).ok();
-                    }
-                    Method::Put if url == "/d" => {
-                        let response = Response::from_string(format!("m: {}", content));
-                        request.respond(response).ok();
-                    }
-                    Method::Delete if url == "/e" => {
-                        let response = Response::from_string(format!("n: {}", content));
-                        request.respond(response).ok();
-                    }
-                    Method::Trace if url == "/f" => {
-                        let response = Response::from_string(format!("o: {}", content));
-                        request.respond(response).ok();
-                    }
-                    Method::Options if url == "/g" => {
-                        let response = Response::from_string(format!("p: {}", content));
-                        request.respond(response).ok();
-                    }
-                    Method::Connect if url == "/h" => {
-                        let response = Response::from_string(format!("q: {}", content));
-                        request.respond(response).ok();
-                    }
-                    Method::Patch if url == "/i" => {
-                        let response = Response::from_string(format!("r: {}", content));
-                        request.respond(response).ok();
-                    }
+                });
+            }
+        });
+    }
 
-                    _ => {
-                        request
-                            .respond(Response::from_string("Not Found").with_status_code(404))
-                            .ok();
-                    }
+    pub fn url(req: &str) -> String {
+        format!("http://localhost:35562{}", req)
+    }
+
+    pub fn get_body(request: Result<minreq::Response, minreq::Error>) -> String {
+        match request {
+            Ok(response) => match response.as_str() {
+                Ok(str) => String::from(str),
+                Err(err) => {
+                    println!("\n[ERROR]: {}\n", err);
+                    String::new()
                 }
-            });
-        }
-    });
-}
-
-pub fn url(req: &str) -> String {
-    format!("http://localhost:35562{}", req)
-}
-
-pub fn get_body(request: Result<minreq::Response, minreq::Error>) -> String {
-    match request {
-        Ok(response) => match response.as_str() {
-            Ok(str) => String::from(str),
+            },
             Err(err) => {
                 println!("\n[ERROR]: {}\n", err);
                 String::new()
             }
-        },
-        Err(err) => {
-            println!("\n[ERROR]: {}\n", err);
-            String::new()
         }
     }
-}
 
-pub fn get_status_code(request: Result<minreq::Response, minreq::Error>) -> i32 {
-    match request {
-        Ok(response) => response.status_code,
-        Err(err) => {
-            println!("\n[ERROR]: {}\n", err);
-            -1
+    pub fn get_status_code(request: Result<minreq::Response, minreq::Error>) -> i32 {
+        match request {
+            Ok(response) => response.status_code,
+            Err(err) => {
+                println!("\n[ERROR]: {}\n", err);
+                -1
+            }
         }
     }
 }


### PR DESCRIPTION
Minreq is now able to be used in a browser with wasm.
The native version has not changed at all thanks to conditional compilation.
The code is not pretty because of a lot of #[cfg] .
It should be possible to reorganize the code