### PR TITLE
http connect proxy support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ travis-ci = { repository = "neonmoe/minreq" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
+base64 = "0.12"
 rustls = { version = "^0.16.0", optional = true }
 webpki-roots = { version = "^0.18.0", optional = true }
 webpki = { version = "^0.21.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ default = []
 
 https = ["rustls", "webpki-roots", "webpki", "lazy_static"]
 json-using-serde = ["serde", "serde_json"]
+proxy = []
 
 [[example]]
 name = "hello"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -158,6 +158,7 @@ impl Connection {
     }
 
     fn connect(&self) -> Result<TcpStream, Error> {
+        #[cfg(feature = "proxy")]
         match self.request.proxy {
             Some(ref proxy) => {
                 // do proxy things
@@ -184,6 +185,9 @@ impl Connection {
             }
             None => TcpStream::connect(&self.request.host).map_err(Error::from),
         }
+
+        #[cfg(not(feature = "proxy"))]
+        TcpStream::connect(&self.request.host).map_err(Error::from)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,15 @@ pub enum Error {
     /// characters, but it could not be converted into punycode
     /// because the `punycode` feature was not enabled.
     PunycodeFeatureNotEnabled,
+    /// The provided proxy information was not properly formatted.
+    /// Supported proxy format is `[user:password@]host:port`.
+    BadProxy,
+    /// The provided credentials were rejected by the proxy server.
+    BadProxyCreds,
+    /// The provided proxy credentials were malformed.
+    ProxyConnect,
+    /// The provided credentials were rejected by the proxy server.
+    InvalidProxyCreds,
 
     /// This is a special error case, one that should never be
     /// returned! Think of this as a cleaner alternative to calling
@@ -69,6 +78,10 @@ impl fmt::Display for Error {
             HttpsFeatureNotEnabled => write!(f, "request url contains https:// but the https feature is not enabled"),
             PunycodeFeatureNotEnabled => write!(f, "non-ascii urls needs to be converted into punycode, and the feature is missing"),
             PunycodeConversionFailed => write!(f, "non-ascii url conversion to punycode failed"),
+            BadProxy => write!(f, "the provided proxy information is malformed"),
+            BadProxyCreds => write!(f, "the provided proxy credentials are malformed"),
+            ProxyConnect => write!(f, "could not connect to the proxy server"),
+            InvalidProxyCreds => write!(f, "the provided proxy credentials are invalid"),
             Other(msg) => write!(f, "error in minreq: please open an issue in the minreq repo, include the following: '{}'", msg),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,23 @@
 //! # Ok(()) }
 //! ```
 //!
+//! ## Proxy
+//! To use a proxy server, simply provide create a `Proxy` instance
+//! and use `.with_proxy()` on your request.
+//!
+//! Supported proxy formats are `host:port` and `user:password@proxy:host`.
+//! Only HTTP CONNECT proxies are supported at this time.
+//! ```no_run
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let proxy = minreq::Proxy::new("localhost:8080")?;
+//! let response = minreq::post("http://httpbin.org/delay/1")
+//!     .with_proxy(proxy)
+//!     .send()?;
+//! println!("{}", response.as_str()?);
+//! # Ok(()) }
+//! ```
+//!
+//!
 //! # Timeouts
 //! By default, a request has no timeout.  You can change this in two ways:
 //! - Use [`with_timeout`](struct.Request.html#method.with_timeout) on
@@ -169,9 +186,11 @@ extern crate webpki_roots;
 
 mod connection;
 mod error;
+mod proxy;
 mod request;
 mod response;
 
 pub use error::*;
+pub use proxy::*;
 pub use request::*;
 pub use response::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,10 @@
 //! [`PunycodeFeatureNotEnabled`](enum.Error.html#variant.PunycodeFeatureNotEnabled)
 //! error.
 //!
+//! ## `proxy`
+//!
+//! This feature enables proxy support.  
+//!
 //! # Examples
 //!
 //! ## Get
@@ -141,11 +145,14 @@
 //! Only HTTP CONNECT proxies are supported at this time.
 //! ```no_run
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let proxy = minreq::Proxy::new("localhost:8080")?;
-//! let response = minreq::post("http://httpbin.org/delay/1")
-//!     .with_proxy(proxy)
-//!     .send()?;
-//! println!("{}", response.as_str()?);
+//! #[cfg(feature = "proxy")]
+//! {
+//!     let proxy = minreq::Proxy::new("localhost:8080")?;
+//!     let response = minreq::post("http://httpbin.org/delay/1")
+//!         .with_proxy(proxy)
+//!         .send()?;
+//!     println!("{}", response.as_str()?);
+//! }
 //! # Ok(()) }
 //! ```
 //!
@@ -186,11 +193,13 @@ extern crate webpki_roots;
 
 mod connection;
 mod error;
+#[cfg(feature = "proxy")]
 mod proxy;
 mod request;
 mod response;
 
 pub use error::*;
+#[cfg(feature = "proxy")]
 pub use proxy::*;
 pub use request::*;
 pub use response::*;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,0 +1,153 @@
+use crate::error::Error;
+
+/// Kind of proxy connection (Basic, Digest, etc)
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum ProxyKind {
+    Basic,
+}
+
+/// Proxy server definition
+#[derive(Clone, Debug, PartialEq)]
+pub struct Proxy {
+    pub(crate) server: String,
+    pub(crate) port: u32,
+    pub(crate) user: Option<String>,
+    pub(crate) password: Option<String>,
+    pub(crate) kind: ProxyKind,
+}
+
+impl Proxy {
+    fn parse_creds<S: AsRef<str>>(
+        creds: &Option<S>,
+    ) -> Result<(Option<String>, Option<String>), Error> {
+        match creds {
+            Some(creds) => {
+                let mut parts = creds
+                    .as_ref()
+                    .splitn(2, ':')
+                    .collect::<Vec<&str>>()
+                    .into_iter();
+
+                if parts.len() != 2 {
+                    Err(Error::BadProxyCreds)
+                } else {
+                    Ok((
+                        parts.next().map(String::from),
+                        parts.next().map(String::from),
+                    ))
+                }
+            }
+            None => Ok((None, None)),
+        }
+    }
+
+    fn parse_address<S: AsRef<str>>(host: &Option<S>) -> Result<(String, Option<u32>), Error> {
+        match host {
+            Some(host) => {
+                let mut parts = host.as_ref().split(':').collect::<Vec<&str>>().into_iter();
+                let host = parts.next().ok_or(Error::BadProxy)?;
+                let port = parts.next();
+                Ok((
+                    String::from(host),
+                    port.and_then(|port| port.parse::<u32>().ok()),
+                ))
+            }
+            None => Err(Error::BadProxy),
+        }
+    }
+
+    fn use_authorization(&self) -> bool {
+        self.user.is_some() && self.password.is_some()
+    }
+
+    /// A proxy server
+    ///
+    /// Create a proxy server to be used with HTTP(S) connections.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let proxy = minreq::Proxy::new("user:password@localhost:8080").unwrap();
+    /// let request = minreq::post("http://example.com").with_proxy(proxy);
+    /// ```
+    ///
+    pub fn new<S: AsRef<str>>(proxy: S) -> Result<Self, Error> {
+        let mut parts = proxy
+            .as_ref()
+            .rsplitn(2, '@')
+            .collect::<Vec<&str>>()
+            .into_iter()
+            .rev();
+
+        let (user, password) = if parts.len() == 2 {
+            Proxy::parse_creds(&parts.next())?
+        } else {
+            (None, None)
+        };
+
+        let (server, port) = Proxy::parse_address(&parts.next())?;
+
+        Ok(Self {
+            server,
+            user,
+            password,
+            port: port.unwrap_or(8080),
+            kind: ProxyKind::Basic,
+        })
+    }
+
+    pub(crate) fn connect<S: AsRef<str>>(&self, host: S) -> String {
+        let authorization = if self.use_authorization() {
+            match self.kind {
+                ProxyKind::Basic => {
+                    let creds = base64::encode(&format!(
+                        "{}:{}",
+                        self.user.clone().unwrap_or_default(),
+                        self.password.clone().unwrap_or_default()
+                    ));
+                    format!("Proxy-Authorization: basic {}\r\n", creds)
+                }
+            }
+        } else {
+            String::new()
+        };
+
+        format!(
+            "CONNECT {} HTTP/1.1\r\n\
+Host: {}\r\n\
+User-Agent: something/1.0.0\r\n\
+Proxy-Connection: Keep-Alive\r\n\
+{}\
+\r\n",
+            host.as_ref(),
+            host.as_ref(),
+            authorization
+        )
+    }
+
+    pub(crate) fn verify_response(response: &[u8]) -> Result<(), Error> {
+        let response_string = String::from_utf8_lossy(response);
+        let top_line = response_string.lines().next().ok_or(Error::ProxyConnect)?;
+        let status_code = top_line.split_whitespace().nth(1).ok_or(Error::BadProxy)?;
+
+        match status_code {
+            "200" => Ok(()),
+            "401" | "407" => Err(Error::InvalidProxyCreds),
+            _ => Err(Error::BadProxy),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Proxy;
+
+    #[test]
+    fn parse_proxy() {
+        let proxy = Proxy::new("user:p@ssw0rd@localhost:9999").unwrap();
+        assert_eq!(proxy.user, Some(String::from("user")));
+        assert_eq!(proxy.password, Some(String::from("p@ssw0rd")));
+        assert_eq!(proxy.server, String::from("localhost"));
+        assert_eq!(proxy.port, 9999);
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,5 @@
 use crate::connection::Connection;
+use crate::proxy::Proxy;
 use crate::{Error, Response, ResponseLazy};
 use std::collections::HashMap;
 use std::fmt;
@@ -77,6 +78,7 @@ pub struct Request {
     max_redirects: usize,
     https: bool,
     pub(crate) redirects: Vec<(bool, URL, URL)>,
+    pub(crate) proxy: Option<Proxy>,
 }
 
 impl Request {
@@ -96,6 +98,7 @@ impl Request {
             max_redirects: 100,
             https,
             redirects: Vec::new(),
+            proxy: None,
         }
     }
 
@@ -269,6 +272,12 @@ impl Request {
         } else {
             Ok(self)
         }
+    }
+
+    /// Sets the proxy to use.
+    pub fn with_proxy(mut self, proxy: Proxy) -> Request {
+        self.proxy = Some(proxy);
+        self
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,5 @@
 use crate::connection::Connection;
+#[cfg(feature = "proxy")]
 use crate::proxy::Proxy;
 use crate::{Error, Response, ResponseLazy};
 use std::collections::HashMap;
@@ -78,6 +79,7 @@ pub struct Request {
     max_redirects: usize,
     https: bool,
     pub(crate) redirects: Vec<(bool, URL, URL)>,
+    #[cfg(feature = "proxy")]
     pub(crate) proxy: Option<Proxy>,
 }
 
@@ -98,6 +100,7 @@ impl Request {
             max_redirects: 100,
             https,
             redirects: Vec::new(),
+            #[cfg(feature = "proxy")]
             proxy: None,
         }
     }
@@ -275,6 +278,7 @@ impl Request {
     }
 
     /// Sets the proxy to use.
+    #[cfg(feature = "proxy")]
     pub fn with_proxy(mut self, proxy: Proxy) -> Request {
         self.proxy = Some(proxy);
         self

--- a/src/response.rs
+++ b/src/response.rs
@@ -455,7 +455,7 @@ fn read_line(stream: &mut Bytes<HttpStream>) -> Result<String, Error> {
         }
     }
     match String::from_utf8(bytes) {
-        Ok(line) => Ok(line.to_string()),
+        Ok(line) => Ok(line),
         Err(_) => Err(Error::InvalidUtf8InResponse),
     }
 }


### PR DESCRIPTION
I added support for http(s) proxies. Tested this with `tinyproxy` using unauthenticated and authenticated setups. Also added some documentation around it. Hopefully this is helpful.

If you want I could put it behind a `proxy` feature flag as well.