### PR TITLE
Add more https libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,21 @@ lazy_static = { version = "^1.4.0", optional = true }
 serde = { version = "^1.0.101", optional = true }
 serde_json = { version = "^1.0.41", optional = true }
 punycode = { version = "^0.4.1", optional = true }
+log = { version = "0.4.5", optional = true }
+openssl = { version = "0.10.29", optional = true }
+openssl-probe = { version = "0.1", optional = true }
+native-tls = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tiny_http = "^0.6.2"
 serde_derive = "^1.0.101"
 
 [features]
-default = []
-
-https = ["rustls", "webpki-roots", "webpki", "lazy_static"]
+https = ["https-rustls"]
+https-rustls = ["rustls", "lazy_static", "webpki-roots", "webpki"]
+https-bundled = ["log", "openssl/vendored"]
+https-bundled-probe = ["https-bundled", "openssl-probe"]
+https-native = ["native-tls"]
 json-using-serde = ["serde", "serde_json"]
 proxy = ["base64"]
 
@@ -46,3 +52,5 @@ name = "iterator"
 [[example]]
 name = "json"
 required-features = ["json-using-serde"]
+
+# vim: ft=conf

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,19 @@
+use std::env;
+
+fn main() {
+    if let Ok(version) = env::var("DEP_OPENSSL_VERSION_NUMBER") {
+        let version = u64::from_str_radix(&version, 16).unwrap();
+
+        if version >= 0x1_01_00_00_0 {
+            println!("cargo:rustc-cfg=have_min_max_version");
+        }
+    }
+
+    if let Ok(version) = env::var("DEP_OPENSSL_LIBRESSL_VERSION_NUMBER") {
+        let version = u64::from_str_radix(&version, 16).unwrap();
+
+        if version >= 0x2_06_01_00_0 {
+            println!("cargo:rustc-cfg=have_min_max_version");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! Below is the list of all available features.
 //!
-//! ## `https`
+//! ## `https` or `https-rustls`
 //!
 //! This feature uses the (very good)
 //! [`rustls`](https://crates.io/crates/rustls) crate to secure the
@@ -26,6 +26,25 @@
 //! `https://` will fail and return a
 //! [`HttpsFeatureNotEnabled`](enum.Error.html#variant.HttpsFeatureNotEnabled)
 //! error.
+//!
+//! ## `https-native`
+//!
+//! Like `https`, but uses [`tls-native`](https://crates.io/crates/native-tls)
+//! instead of `rustls`.
+//!
+//! ## `https-bundled`
+//!
+//! Like `https`, but uses a statically linked copy of the OpenSSL library
+//! (provided by [`openssl-sys`](https://crates.io/crates/openssl-sys) with
+//! features = "vendored"). This feature on its own doesn't provide any
+//! detection of where your root certificates are installed. They can be specified
+//! via the environment variables `SSL_CERT_FILE` or `SSL_CERT_DIR`.
+//!
+//! ## `https-bundled-probe`
+//!
+//! Like `https-bundled`, but also includes the
+//! [`openssl-probe`](https://crates.io/crates/openssl-probe) crate to auto-detect
+//! root certificates installed in common locations.
 //!
 //! ## `json-using-serde`
 //!
@@ -180,16 +199,26 @@
 
 #![deny(missing_docs)]
 
-#[cfg(feature = "https")]
+#[cfg(feature = "rustls")]
 extern crate rustls;
+#[cfg(feature = "openssl")]
+mod native_tls;
+#[cfg(feature = "openssl")]
+#[macro_use]
+extern crate log;
+#[cfg(feature = "rustls")]
+extern crate webpki;
+#[cfg(feature = "rustls")]
+extern crate webpki_roots;
+#[cfg(feature = "openssl-probe")]
+extern crate openssl_probe;
+#[cfg(feature = "native-tls")]
+extern crate native_tls;
+
 #[cfg(feature = "json-using-serde")]
 extern crate serde;
 #[cfg(feature = "json-using-serde")]
 extern crate serde_json;
-#[cfg(feature = "https")]
-extern crate webpki;
-#[cfg(feature = "https")]
-extern crate webpki_roots;
 
 mod connection;
 mod error;

--- a/src/native_tls/LICENSE-MIT
+++ b/src/native_tls/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright (c) 2016 The rust-native-tls Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/native_tls/mod.rs
+++ b/src/native_tls/mod.rs
@@ -1,0 +1,595 @@
+// Derived from https://lib.rs/crates/native-tls.
+
+use std::any::Any;
+use std::error;
+use std::fmt;
+use std::io;
+use std::result;
+
+// moved to ../lib.rs
+// #[macro_use]
+// extern crate log;
+
+#[path = "openssl.rs"]
+mod imp;
+
+/// A typedef of the result-type returned by many methods.
+pub type Result<T> = result::Result<T, Error>;
+
+/// An error returned from the TLS implementation.
+pub struct Error(imp::Error);
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        error::Error::source(&self.0)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, fmt)
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+impl From<imp::Error> for Error {
+    fn from(err: imp::Error) -> Error {
+        Error(err)
+    }
+}
+
+/// A cryptographic identity.
+///
+/// An identity is an X509 certificate along with its corresponding private key and chain of certificates to a trusted
+/// root.
+#[derive(Clone)]
+pub struct Identity(imp::Identity);
+
+/*
+impl Identity {
+    /// Parses a DER-formatted PKCS #12 archive, using the specified password to decrypt the key.
+    ///
+    /// The archive should contain a leaf certificate and its private key, as well any intermediate
+    /// certificates that should be sent to clients to allow them to build a chain to a trusted
+    /// root. The chain certificates should be in order from the leaf certificate towards the root.
+    ///
+    /// PKCS #12 archives typically have the file extension `.p12` or `.pfx`, and can be created
+    /// with the OpenSSL `pkcs12` tool:
+    ///
+    /// ```bash
+    /// openssl pkcs12 -export -out identity.pfx -inkey key.pem -in cert.pem -certfile chain_certs.pem
+    /// ```
+    pub fn from_pkcs12(der: &[u8], password: &str) -> Result<Identity> {
+        let identity = imp::Identity::from_pkcs12(der, password)?;
+        Ok(Identity(identity))
+    }
+}
+*/
+
+/// An X509 certificate.
+#[derive(Clone)]
+pub struct Certificate(imp::Certificate);
+
+/*
+impl Certificate {
+    /// Parses a DER-formatted X509 certificate.
+    pub fn from_der(der: &[u8]) -> Result<Certificate> {
+        let cert = imp::Certificate::from_der(der)?;
+        Ok(Certificate(cert))
+    }
+
+    /// Parses a PEM-formatted X509 certificate.
+    pub fn from_pem(der: &[u8]) -> Result<Certificate> {
+        let cert = imp::Certificate::from_pem(der)?;
+        Ok(Certificate(cert))
+    }
+
+    /// Returns the DER-encoded representation of this certificate.
+    pub fn to_der(&self) -> Result<Vec<u8>> {
+        let der = self.0.to_der()?;
+        Ok(der)
+    }
+}
+*/
+
+/// A TLS stream which has been interrupted midway through the handshake process.
+pub struct MidHandshakeTlsStream<S>(imp::MidHandshakeTlsStream<S>);
+
+impl<S> fmt::Debug for MidHandshakeTlsStream<S>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+/*
+impl<S> MidHandshakeTlsStream<S> {
+    /// Returns a shared reference to the inner stream.
+    pub fn get_ref(&self) -> &S {
+        self.0.get_ref()
+    }
+
+    /// Returns a mutable reference to the inner stream.
+    pub fn get_mut(&mut self) -> &mut S {
+        self.0.get_mut()
+    }
+}
+
+impl<S> MidHandshakeTlsStream<S>
+where
+    S: io::Read + io::Write,
+{
+    /// Restarts the handshake process.
+    ///
+    /// If the handshake completes successfully then the negotiated stream is
+    /// returned. If there is a problem, however, then an error is returned.
+    /// Note that the error may not be fatal. For example if the underlying
+    /// stream is an asynchronous one then `HandshakeError::WouldBlock` may
+    /// just mean to wait for more I/O to happen later.
+    pub fn handshake(self) -> result::Result<TlsStream<S>, HandshakeError<S>> {
+        match self.0.handshake() {
+            Ok(s) => Ok(TlsStream(s)),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+*/
+
+/// An error returned from `ClientBuilder::handshake`.
+#[derive(Debug)]
+pub enum HandshakeError<S> {
+    /// A fatal error.
+    Failure(Error),
+
+    /// A stream interrupted midway through the handshake process due to a
+    /// `WouldBlock` error.
+    ///
+    /// Note that this is not a fatal error and it should be safe to call
+    /// `handshake` at a later time once the stream is ready to perform I/O
+    /// again.
+    WouldBlock(MidHandshakeTlsStream<S>),
+}
+
+impl<S> error::Error for HandshakeError<S>
+where
+    S: Any + fmt::Debug,
+{
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            HandshakeError::Failure(ref e) => Some(e),
+            HandshakeError::WouldBlock(_) => None,
+        }
+    }
+}
+
+impl<S> fmt::Display for HandshakeError<S>
+where
+    S: Any + fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            HandshakeError::Failure(ref e) => fmt::Display::fmt(e, fmt),
+            HandshakeError::WouldBlock(_) => fmt.write_str("the handshake process was interrupted"),
+        }
+    }
+}
+
+impl<S> From<imp::HandshakeError<S>> for HandshakeError<S> {
+    fn from(e: imp::HandshakeError<S>) -> HandshakeError<S> {
+        match e {
+            imp::HandshakeError::Failure(e) => HandshakeError::Failure(Error(e)),
+            imp::HandshakeError::WouldBlock(s) => {
+                HandshakeError::WouldBlock(MidHandshakeTlsStream(s))
+            }
+        }
+    }
+}
+
+/// SSL/TLS protocol versions.
+#[derive(Debug, Copy, Clone)]
+#[allow(dead_code)]
+pub enum Protocol {
+    /// The SSL 3.0 protocol.
+    ///
+    /// # Warning
+    ///
+    /// SSL 3.0 has severe security flaws, and should not be used unless absolutely necessary. If
+    /// you are not sure if you need to enable this protocol, you should not.
+    Sslv3,
+    /// The TLS 1.0 protocol.
+    Tlsv10,
+    /// The TLS 1.1 protocol.
+    Tlsv11,
+    /// The TLS 1.2 protocol.
+    Tlsv12,
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+/// A builder for `TlsConnector`s.
+pub struct TlsConnectorBuilder {
+    identity: Option<Identity>,
+    min_protocol: Option<Protocol>,
+    max_protocol: Option<Protocol>,
+    root_certificates: Vec<Certificate>,
+    accept_invalid_certs: bool,
+    accept_invalid_hostnames: bool,
+    use_sni: bool,
+    disable_built_in_roots: bool,
+}
+
+impl TlsConnectorBuilder {
+    /*
+    /// Sets the identity to be used for client certificate authentication.
+    pub fn identity(&mut self, identity: Identity) -> &mut TlsConnectorBuilder {
+        self.identity = Some(identity);
+        self
+    }
+
+    /// Sets the minimum supported protocol version.
+    ///
+    /// A value of `None` enables support for the oldest protocols supported by the implementation.
+    ///
+    /// Defaults to `Some(Protocol::Tlsv10)`.
+    pub fn min_protocol_version(&mut self, protocol: Option<Protocol>) -> &mut TlsConnectorBuilder {
+        self.min_protocol = protocol;
+        self
+    }
+
+    /// Sets the maximum supported protocol version.
+    ///
+    /// A value of `None` enables support for the newest protocols supported by the implementation.
+    ///
+    /// Defaults to `None`.
+    pub fn max_protocol_version(&mut self, protocol: Option<Protocol>) -> &mut TlsConnectorBuilder {
+        self.max_protocol = protocol;
+        self
+    }
+
+    /// Adds a certificate to the set of roots that the connector will trust.
+    ///
+    /// The connector will use the system's trust root by default. This method can be used to add
+    /// to that set when communicating with servers not trusted by the system.
+    ///
+    /// Defaults to an empty set.
+    pub fn add_root_certificate(&mut self, cert: Certificate) -> &mut TlsConnectorBuilder {
+        self.root_certificates.push(cert);
+        self
+    }
+
+    /// Controls the use of built-in system certificates during certificate validation.
+    ///
+    /// Defaults to `false` -- built-in system certs will be used.
+    pub fn disable_built_in_roots(&mut self, disable: bool) -> &mut TlsConnectorBuilder {
+        self.disable_built_in_roots = disable;
+        self
+    }
+
+    /// Controls the use of certificate validation.
+    ///
+    /// Defaults to `false`.
+    ///
+    /// # Warning
+    ///
+    /// You should think very carefully before using this method. If invalid certificates are trusted, *any*
+    /// certificate for *any* site will be trusted for use. This includes expired certificates. This introduces
+    /// significant vulnerabilities, and should only be used as a last resort.
+    pub fn danger_accept_invalid_certs(
+        &mut self,
+        accept_invalid_certs: bool,
+    ) -> &mut TlsConnectorBuilder {
+        self.accept_invalid_certs = accept_invalid_certs;
+        self
+    }
+
+    /// Controls the use of Server Name Indication (SNI).
+    ///
+    /// Defaults to `true`.
+    pub fn use_sni(&mut self, use_sni: bool) -> &mut TlsConnectorBuilder {
+        self.use_sni = use_sni;
+        self
+    }
+
+    /// Controls the use of hostname verification.
+    ///
+    /// Defaults to `false`.
+    ///
+    /// # Warning
+    ///
+    /// You should think very carefully before using this method. If invalid hostnames are trusted, *any* valid
+    /// certificate for *any* site will be trusted for use. This introduces significant vulnerabilities, and should
+    /// only be used as a last resort.
+    pub fn danger_accept_invalid_hostnames(
+        &mut self,
+        accept_invalid_hostnames: bool,
+    ) -> &mut TlsConnectorBuilder {
+        self.accept_invalid_hostnames = accept_invalid_hostnames;
+        self
+    }
+    */
+
+    /// Creates a new `TlsConnector`.
+    pub fn build(&self) -> Result<TlsConnector> {
+        let connector = imp::TlsConnector::new(self)?;
+        Ok(TlsConnector(connector))
+    }
+}
+
+/// A builder for client-side TLS connections.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use native_tls::TlsConnector;
+/// use std::io::{Read, Write};
+/// use std::net::TcpStream;
+///
+/// let connector = TlsConnector::new().unwrap();
+///
+/// let stream = TcpStream::connect("google.com:443").unwrap();
+/// let mut stream = connector.connect("google.com", stream).unwrap();
+///
+/// stream.write_all(b"GET / HTTP/1.0\r\n\r\n").unwrap();
+/// let mut res = vec![];
+/// stream.read_to_end(&mut res).unwrap();
+/// println!("{}", String::from_utf8_lossy(&res));
+/// ```
+#[derive(Clone)]
+pub struct TlsConnector(imp::TlsConnector);
+
+impl TlsConnector {
+    /// Returns a new connector with default settings.
+    pub fn new() -> Result<TlsConnector> {
+        TlsConnector::builder().build()
+    }
+
+    /// Returns a new builder for a `TlsConnector`.
+    pub fn builder() -> TlsConnectorBuilder {
+        TlsConnectorBuilder {
+            identity: None,
+            min_protocol: Some(Protocol::Tlsv10),
+            max_protocol: None,
+            root_certificates: vec![],
+            use_sni: true,
+            accept_invalid_certs: false,
+            accept_invalid_hostnames: false,
+            disable_built_in_roots: false,
+        }
+    }
+
+    /// Initiates a TLS handshake.
+    ///
+    /// The provided domain will be used for both SNI and certificate hostname
+    /// validation.
+    ///
+    /// If the socket is nonblocking and a `WouldBlock` error is returned during
+    /// the handshake, a `HandshakeError::WouldBlock` error will be returned
+    /// which can be used to restart the handshake when the socket is ready
+    /// again.
+    ///
+    /// The domain is ignored if both SNI and hostname verification are
+    /// disabled.
+    pub fn connect<S>(
+        &self,
+        domain: &str,
+        stream: S,
+    ) -> result::Result<TlsStream<S>, HandshakeError<S>>
+    where
+        S: io::Read + io::Write,
+    {
+        let s = self.0.connect(domain, stream)?;
+        Ok(TlsStream(s))
+    }
+}
+
+/*
+/// A builder for `TlsAcceptor`s.
+pub struct TlsAcceptorBuilder {
+    identity: Identity,
+    min_protocol: Option<Protocol>,
+    max_protocol: Option<Protocol>,
+}
+
+impl TlsAcceptorBuilder {
+    /// Sets the minimum supported protocol version.
+    ///
+    /// A value of `None` enables support for the oldest protocols supported by the implementation.
+    ///
+    /// Defaults to `Some(Protocol::Tlsv10)`.
+    pub fn min_protocol_version(&mut self, protocol: Option<Protocol>) -> &mut TlsAcceptorBuilder {
+        self.min_protocol = protocol;
+        self
+    }
+
+    /// Sets the maximum supported protocol version.
+    ///
+    /// A value of `None` enables support for the newest protocols supported by the implementation.
+    ///
+    /// Defaults to `None`.
+    pub fn max_protocol_version(&mut self, protocol: Option<Protocol>) -> &mut TlsAcceptorBuilder {
+        self.max_protocol = protocol;
+        self
+    }
+
+    /// Creates a new `TlsAcceptor`.
+    pub fn build(&self) -> Result<TlsAcceptor> {
+        let acceptor = imp::TlsAcceptor::new(self)?;
+        Ok(TlsAcceptor(acceptor))
+    }
+}
+*/
+
+/// A builder for server-side TLS connections.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use native_tls::{Identity, TlsAcceptor, TlsStream};
+/// use std::fs::File;
+/// use std::io::{Read};
+/// use std::net::{TcpListener, TcpStream};
+/// use std::sync::Arc;
+/// use std::thread;
+///
+/// let mut file = File::open("identity.pfx").unwrap();
+/// let mut identity = vec![];
+/// file.read_to_end(&mut identity).unwrap();
+/// let identity = Identity::from_pkcs12(&identity, "hunter2").unwrap();
+///
+/// let listener = TcpListener::bind("0.0.0.0:8443").unwrap();
+/// let acceptor = TlsAcceptor::new(identity).unwrap();
+/// let acceptor = Arc::new(acceptor);
+///
+/// fn handle_client(stream: TlsStream<TcpStream>) {
+///     // ...
+/// }
+///
+/// for stream in listener.incoming() {
+///     match stream {
+///         Ok(stream) => {
+///             let acceptor = acceptor.clone();
+///             thread::spawn(move || {
+///                 let stream = acceptor.accept(stream).unwrap();
+///                 handle_client(stream);
+///             });
+///         }
+///         Err(e) => { /* connection failed */ }
+///     }
+/// }
+/// ```
+#[derive(Clone)]
+pub struct TlsAcceptor(imp::TlsAcceptor);
+
+/*
+impl TlsAcceptor {
+    /// Creates a acceptor with default settings.
+    ///
+    /// The identity acts as the server's private key/certificate chain.
+    pub fn new(identity: Identity) -> Result<TlsAcceptor> {
+        TlsAcceptor::builder(identity).build()
+    }
+
+    /// Returns a new builder for a `TlsAcceptor`.
+    ///
+    /// The identity acts as the server's private key/certificate chain.
+    pub fn builder(identity: Identity) -> TlsAcceptorBuilder {
+        TlsAcceptorBuilder {
+            identity,
+            min_protocol: Some(Protocol::Tlsv10),
+            max_protocol: None,
+        }
+    }
+
+    /// Initiates a TLS handshake.
+    ///
+    /// If the socket is nonblocking and a `WouldBlock` error is returned during
+    /// the handshake, a `HandshakeError::WouldBlock` error will be returned
+    /// which can be used to restart the handshake when the socket is ready
+    /// again.
+    pub fn accept<S>(&self, stream: S) -> result::Result<TlsStream<S>, HandshakeError<S>>
+    where
+        S: io::Read + io::Write,
+    {
+        match self.0.accept(stream) {
+            Ok(s) => Ok(TlsStream(s)),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+*/
+
+/// A stream managing a TLS session.
+pub struct TlsStream<S>(imp::TlsStream<S>);
+
+impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+impl<S> TlsStream<S> {
+    /// Returns a shared reference to the inner stream.
+    pub fn get_ref(&self) -> &S {
+        self.0.get_ref()
+    }
+
+    /// Returns a mutable reference to the inner stream.
+    #[allow(dead_code)]
+    pub fn get_mut(&mut self) -> &mut S {
+        self.0.get_mut()
+    }
+}
+
+/*
+impl<S: io::Read + io::Write> TlsStream<S> {
+    /// Returns the number of bytes that can be read without resulting in any
+    /// network calls.
+    pub fn buffered_read_size(&self) -> Result<usize> {
+        Ok(self.0.buffered_read_size()?)
+    }
+
+    /// Returns the peer's leaf certificate, if available.
+    pub fn peer_certificate(&self) -> Result<Option<Certificate>> {
+        Ok(self.0.peer_certificate()?.map(Certificate))
+    }
+
+    /// Returns the tls-server-end-point channel binding data as defined in [RFC 5929].
+    ///
+    /// [RFC 5929]: https://tools.ietf.org/html/rfc5929
+    pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>> {
+        Ok(self.0.tls_server_end_point()?)
+    }
+
+    /// Shuts down the TLS session.
+    pub fn shutdown(&mut self) -> io::Result<()> {
+        self.0.shutdown()?;
+        Ok(())
+    }
+}
+*/
+
+impl<S: io::Read + io::Write> io::Read for TlsStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl<S: io::Read + io::Write> io::Write for TlsStream<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+fn _check_kinds() {
+    use std::net::TcpStream;
+
+    fn is_sync<T: Sync>() {}
+    fn is_send<T: Send>() {}
+    is_sync::<Error>();
+    is_send::<Error>();
+    is_sync::<TlsConnectorBuilder>();
+    is_send::<TlsConnectorBuilder>();
+    is_sync::<TlsConnector>();
+    is_send::<TlsConnector>();
+    /*
+    is_sync::<TlsAcceptorBuilder>();
+    is_send::<TlsAcceptorBuilder>();
+    */
+    is_sync::<TlsAcceptor>();
+    is_send::<TlsAcceptor>();
+    is_sync::<TlsStream<TcpStream>>();
+    is_send::<TlsStream<TcpStream>>();
+    is_sync::<MidHandshakeTlsStream<TcpStream>>();
+    is_send::<MidHandshakeTlsStream<TcpStream>>();
+}

--- a/src/native_tls/openssl.rs
+++ b/src/native_tls/openssl.rs
@@ -1,0 +1,432 @@
+#[cfg(feature = "openssl-probe")]
+use openssl_probe;
+#[cfg(feature = "openssl-probe")]
+use std::sync::Once;
+
+use ::openssl::error::ErrorStack;
+/*
+use ::openssl::hash::MessageDigest;
+use ::openssl::nid::Nid;
+use ::openssl::pkcs12::Pkcs12;
+*/
+use ::openssl::pkey::PKey;
+use ::openssl::ssl::{
+    self, MidHandshakeSslStream, SslAcceptor, SslConnector, SslContextBuilder, SslMethod,
+    SslVerifyMode,
+};
+use ::openssl::x509::{X509, store::X509StoreBuilder, X509VerifyResult};
+use std::error;
+use std::fmt;
+use std::io;
+
+use super::{Protocol, TlsConnectorBuilder};
+/*
+use super::{Protocol, TlsAcceptorBuilder, TlsConnectorBuilder};
+*/
+use ::openssl::pkey::Private;
+
+#[cfg(have_min_max_version)]
+fn supported_protocols(
+    min: Option<Protocol>,
+    max: Option<Protocol>,
+    ctx: &mut SslContextBuilder,
+) -> Result<(), ErrorStack> {
+    use ::openssl::ssl::SslVersion;
+
+    fn cvt(p: Protocol) -> SslVersion {
+        match p {
+            Protocol::Sslv3 => SslVersion::SSL3,
+            Protocol::Tlsv10 => SslVersion::TLS1,
+            Protocol::Tlsv11 => SslVersion::TLS1_1,
+            Protocol::Tlsv12 => SslVersion::TLS1_2,
+            Protocol::__NonExhaustive => unreachable!(),
+        }
+    }
+
+    ctx.set_min_proto_version(min.map(cvt))?;
+    ctx.set_max_proto_version(max.map(cvt))?;
+
+    Ok(())
+}
+
+#[cfg(not(have_min_max_version))]
+fn supported_protocols(
+    min: Option<Protocol>,
+    max: Option<Protocol>,
+    ctx: &mut SslContextBuilder,
+) -> Result<(), ErrorStack> {
+    use ::openssl::ssl::SslOptions;
+
+    let no_ssl_mask = SslOptions::NO_SSLV2
+        | SslOptions::NO_SSLV3
+        | SslOptions::NO_TLSV1
+        | SslOptions::NO_TLSV1_1
+        | SslOptions::NO_TLSV1_2;
+
+    ctx.clear_options(no_ssl_mask);
+    let mut options = SslOptions::empty();
+    options |= match min {
+        None => SslOptions::empty(),
+        Some(Protocol::Sslv3) => SslOptions::NO_SSLV2,
+        Some(Protocol::Tlsv10) => SslOptions::NO_SSLV2 | SslOptions::NO_SSLV3,
+        Some(Protocol::Tlsv11) => {
+            SslOptions::NO_SSLV2 | SslOptions::NO_SSLV3 | SslOptions::NO_TLSV1
+        }
+        Some(Protocol::Tlsv12) => {
+            SslOptions::NO_SSLV2
+                | SslOptions::NO_SSLV3
+                | SslOptions::NO_TLSV1
+                | SslOptions::NO_TLSV1_1
+        }
+        Some(Protocol::__NonExhaustive) => unreachable!(),
+    };
+    options |= match max {
+        None | Some(Protocol::Tlsv12) => SslOptions::empty(),
+        Some(Protocol::Tlsv11) => SslOptions::NO_TLSV1_2,
+        Some(Protocol::Tlsv10) => SslOptions::NO_TLSV1_1 | SslOptions::NO_TLSV1_2,
+        Some(Protocol::Sslv3) => {
+            SslOptions::NO_TLSV1 | SslOptions::NO_TLSV1_1 | SslOptions::NO_TLSV1_2
+        }
+        Some(Protocol::__NonExhaustive) => unreachable!(),
+    };
+
+    ctx.set_options(options);
+
+    Ok(())
+}
+
+#[cfg(feature = "openssl-probe")]
+fn init_trust() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(openssl_probe::init_ssl_cert_env_vars);
+}
+
+#[cfg(target_os = "android")]
+fn load_android_root_certs(connector: &mut SslContextBuilder) -> Result<(), Error> {
+    use std::fs;
+
+    if let Ok(dir) = fs::read_dir("/system/etc/security/cacerts") {
+        let certs = dir
+            .filter_map(|r| r.ok())
+            .filter_map(|e| fs::read(e.path()).ok())
+            .filter_map(|b| X509::from_pem(&b).ok());
+        for cert in certs {
+            if let Err(err) = connector.cert_store_mut().add_cert(cert) {
+                debug!("load_android_root_certs error: {:?}", err);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Normal(ErrorStack),
+    Ssl(ssl::Error, X509VerifyResult),
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            Error::Normal(ref e) => error::Error::source(e),
+            Error::Ssl(ref e, _) => error::Error::source(e),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Normal(ref e) => fmt::Display::fmt(e, fmt),
+            Error::Ssl(ref e, X509VerifyResult::OK) => fmt::Display::fmt(e, fmt),
+            Error::Ssl(ref e, v) => write!(fmt, "{} ({})", e, v),
+        }
+    }
+}
+
+impl From<ErrorStack> for Error {
+    fn from(err: ErrorStack) -> Error {
+        Error::Normal(err)
+    }
+}
+
+#[derive(Clone)]
+pub struct Identity {
+    pkey: PKey<Private>,
+    cert: X509,
+    chain: Vec<X509>,
+}
+
+/*
+impl Identity {
+    pub fn from_pkcs12(buf: &[u8], pass: &str) -> Result<Identity, Error> {
+        let pkcs12 = Pkcs12::from_der(buf)?;
+        let parsed = pkcs12.parse(pass)?;
+        Ok(Identity {
+            pkey: parsed.pkey,
+            cert: parsed.cert,
+            chain: parsed.chain.into_iter().flatten().collect(),
+        })
+    }
+}
+*/
+
+#[derive(Clone)]
+pub struct Certificate(X509);
+
+/*
+impl Certificate {
+    pub fn from_der(buf: &[u8]) -> Result<Certificate, Error> {
+        let cert = X509::from_der(buf)?;
+        Ok(Certificate(cert))
+    }
+
+    pub fn from_pem(buf: &[u8]) -> Result<Certificate, Error> {
+        let cert = X509::from_pem(buf)?;
+        Ok(Certificate(cert))
+    }
+
+    pub fn to_der(&self) -> Result<Vec<u8>, Error> {
+        let der = self.0.to_der()?;
+        Ok(der)
+    }
+}
+*/
+
+pub struct MidHandshakeTlsStream<S>(MidHandshakeSslStream<S>);
+
+impl<S> fmt::Debug for MidHandshakeTlsStream<S>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+/*
+impl<S> MidHandshakeTlsStream<S> {
+    pub fn get_ref(&self) -> &S {
+        self.0.get_ref()
+    }
+
+    pub fn get_mut(&mut self) -> &mut S {
+        self.0.get_mut()
+    }
+}
+
+impl<S> MidHandshakeTlsStream<S>
+where
+    S: io::Read + io::Write,
+{
+    pub fn handshake(self) -> Result<TlsStream<S>, HandshakeError<S>> {
+        match self.0.handshake() {
+            Ok(s) => Ok(TlsStream(s)),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+*/
+
+pub enum HandshakeError<S> {
+    Failure(Error),
+    WouldBlock(MidHandshakeTlsStream<S>),
+}
+
+impl<S> From<ssl::HandshakeError<S>> for HandshakeError<S> {
+    fn from(e: ssl::HandshakeError<S>) -> HandshakeError<S> {
+        match e {
+            ssl::HandshakeError::SetupFailure(e) => HandshakeError::Failure(e.into()),
+            ssl::HandshakeError::Failure(e) => {
+                let v = e.ssl().verify_result();
+                HandshakeError::Failure(Error::Ssl(e.into_error(), v))
+            }
+            ssl::HandshakeError::WouldBlock(s) => {
+                HandshakeError::WouldBlock(MidHandshakeTlsStream(s))
+            }
+        }
+    }
+}
+
+impl<S> From<ErrorStack> for HandshakeError<S> {
+    fn from(e: ErrorStack) -> HandshakeError<S> {
+        HandshakeError::Failure(e.into())
+    }
+}
+
+#[derive(Clone)]
+pub struct TlsConnector {
+    connector: SslConnector,
+    use_sni: bool,
+    accept_invalid_hostnames: bool,
+    accept_invalid_certs: bool,
+}
+
+impl TlsConnector {
+    pub fn new(builder: &TlsConnectorBuilder) -> Result<TlsConnector, Error> {
+        #[cfg(feature = "openssl-probe")]
+        init_trust();
+
+        let mut connector = SslConnector::builder(SslMethod::tls())?;
+        if let Some(ref identity) = builder.identity {
+            connector.set_certificate(&identity.0.cert)?;
+            connector.set_private_key(&identity.0.pkey)?;
+            for cert in identity.0.chain.iter().rev() {
+                connector.add_extra_chain_cert(cert.to_owned())?;
+            }
+        }
+        supported_protocols(builder.min_protocol, builder.max_protocol, &mut connector)?;
+
+        if builder.disable_built_in_roots {
+            connector.set_cert_store(X509StoreBuilder::new()?.build());
+        }
+
+        for cert in &builder.root_certificates {
+            if let Err(err) = connector.cert_store_mut().add_cert((cert.0).0.clone()) {
+                debug!("add_cert error: {:?}", err);
+            }
+        }
+
+        #[cfg(target_os = "android")]
+        load_android_root_certs(&mut connector)?;
+
+        Ok(TlsConnector {
+            connector: connector.build(),
+            use_sni: builder.use_sni,
+            accept_invalid_hostnames: builder.accept_invalid_hostnames,
+            accept_invalid_certs: builder.accept_invalid_certs,
+        })
+    }
+
+    pub fn connect<S>(&self, domain: &str, stream: S) -> Result<TlsStream<S>, HandshakeError<S>>
+    where
+        S: io::Read + io::Write,
+    {
+        let mut ssl = self
+            .connector
+            .configure()?
+            .use_server_name_indication(self.use_sni)
+            .verify_hostname(!self.accept_invalid_hostnames);
+        if self.accept_invalid_certs {
+            ssl.set_verify(SslVerifyMode::NONE);
+        }
+
+        let s = ssl.connect(domain, stream)?;
+        Ok(TlsStream(s))
+    }
+}
+
+#[derive(Clone)]
+pub struct TlsAcceptor(SslAcceptor);
+
+/*
+impl TlsAcceptor {
+    pub fn new(builder: &TlsAcceptorBuilder) -> Result<TlsAcceptor, Error> {
+        let mut acceptor = SslAcceptor::mozilla_intermediate(SslMethod::tls())?;
+        acceptor.set_private_key(&builder.identity.0.pkey)?;
+        acceptor.set_certificate(&builder.identity.0.cert)?;
+        for cert in builder.identity.0.chain.iter().rev() {
+            acceptor.add_extra_chain_cert(cert.to_owned())?;
+        }
+        supported_protocols(builder.min_protocol, builder.max_protocol, &mut acceptor)?;
+
+        Ok(TlsAcceptor(acceptor.build()))
+    }
+
+    pub fn accept<S>(&self, stream: S) -> Result<TlsStream<S>, HandshakeError<S>>
+    where
+        S: io::Read + io::Write,
+    {
+        let s = self.0.accept(stream)?;
+        Ok(TlsStream(s))
+    }
+}
+*/
+
+pub struct TlsStream<S>(ssl::SslStream<S>);
+
+impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+impl<S> TlsStream<S> {
+    pub fn get_ref(&self) -> &S {
+        self.0.get_ref()
+    }
+
+    pub fn get_mut(&mut self) -> &mut S {
+        self.0.get_mut()
+    }
+}
+
+/*
+impl<S: io::Read + io::Write> TlsStream<S> {
+    pub fn buffered_read_size(&self) -> Result<usize, Error> {
+        Ok(self.0.ssl().pending())
+    }
+
+    pub fn peer_certificate(&self) -> Result<Option<Certificate>, Error> {
+        Ok(self.0.ssl().peer_certificate().map(Certificate))
+    }
+
+    pub fn tls_server_end_point(&self) -> Result<Option<Vec<u8>>, Error> {
+        let cert = if self.0.ssl().is_server() {
+            self.0.ssl().certificate().map(|x| x.to_owned())
+        } else {
+            self.0.ssl().peer_certificate()
+        };
+
+        let cert = match cert {
+            Some(cert) => cert,
+            None => return Ok(None),
+        };
+
+        let algo_nid = cert.signature_algorithm().object().nid();
+        let signature_algorithms = match algo_nid.signature_algorithms() {
+            Some(algs) => algs,
+            None => return Ok(None),
+        };
+
+        let md = match signature_algorithms.digest {
+            Nid::MD5 | Nid::SHA1 => MessageDigest::sha256(),
+            nid => match MessageDigest::from_nid(nid) {
+                Some(md) => md,
+                None => return Ok(None),
+            },
+        };
+
+        let digest = cert.digest(md)?;
+
+        Ok(Some(digest.to_vec()))
+    }
+
+    pub fn shutdown(&mut self) -> io::Result<()> {
+        match self.0.shutdown() {
+            Ok(_) => Ok(()),
+            Err(ref e) if e.code() == ssl::ErrorCode::ZERO_RETURN => Ok(()),
+            Err(e) => Err(e
+                .into_io_error()
+                .unwrap_or_else(|e| io::Error::new(io::ErrorKind::Other, e))),
+        }
+    }
+}
+*/
+
+impl<S: io::Read + io::Write> io::Read for TlsStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl<S: io::Read + io::Write> io::Write for TlsStream<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -168,7 +168,7 @@ impl Request {
     /// [`minreq::Error`](enum.Error.html) except
     /// [`SerdeJsonError`](enum.Error.html#variant.SerdeJsonError) and
     /// [`InvalidUtf8InBody`](enum.Error.html#variant.InvalidUtf8InBody).
-    #[cfg(feature = "https")]
+    #[cfg(any(feature = "rustls", feature = "openssl", feature = "native-tls"))]
     pub fn send(self) -> Result<Response, Error> {
         if self.https {
             let is_head = self.method == Method::Head;
@@ -186,7 +186,7 @@ impl Request {
     /// # Errors
     ///
     /// See [`send`](struct.Request.html#method.send).
-    #[cfg(feature = "https")]
+    #[cfg(any(feature = "rustls", feature = "openssl", feature = "native-tls"))]
     pub fn send_lazy(self) -> Result<ResponseLazy, Error> {
         if self.https {
             Connection::new(self).send_https()
@@ -205,7 +205,7 @@ impl Request {
     /// [`minreq::Error`](enum.Error.html) except
     /// [`SerdeJsonError`](enum.Error.html#variant.SerdeJsonError) and
     /// [`InvalidUtf8InBody`](enum.Error.html#variant.InvalidUtf8InBody).
-    #[cfg(not(feature = "https"))]
+    #[cfg(not(any(feature = "rustls", feature = "openssl", feature = "native-tls")))]
     pub fn send(self) -> Result<Response, Error> {
         if self.https {
             Err(Error::HttpsFeatureNotEnabled)
@@ -221,7 +221,7 @@ impl Request {
     /// # Errors
     ///
     /// See [`send`](struct.Request.html#method.send).
-    #[cfg(not(feature = "https"))]
+    #[cfg(not(any(feature = "rustls", feature = "openssl", feature = "native-tls")))]
     pub fn send_lazy(self) -> Result<ResponseLazy, Error> {
         if self.https {
             Err(Error::HttpsFeatureNotEnabled)

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -15,7 +15,7 @@ fn test_headers_char_boundary_panic() {
 }
 
 #[test]
-#[cfg(feature = "https")]
+#[cfg(any(feature = "rustls", feature = "openssl", feature = "native-tls"))]
 // Test based on issue #24: https://github.com/neonmoe/minreq/issues/24
 fn test_dns_name_error() {
     // This will panic by unwrapping a InvalidDNSNameError until the
@@ -24,7 +24,7 @@ fn test_dns_name_error() {
 }
 
 #[test]
-#[cfg(feature = "https")]
+#[cfg(any(feature = "rustls", feature = "openssl", feature = "native-tls"))]
 fn test_https() {
     // TODO: Implement this locally.
     assert_eq!(


### PR DESCRIPTION
Added features that enabled using `https`, but with tls provided by `native-tls` or `openssl-sys` instead of `rustls`. Makes it more attractive to embed this library in other crates that are already using one of those other tls libraries (e.g., I use `openssl-sys` to enable `sqlcipher`).