### PR TITLE
fix InvalidDNSNameError when using ip inside url

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -112,7 +112,7 @@ impl Connection {
         let timeout_at = timeout_duration.map(|d| Instant::now() + d);
 
         // Rustls setup
-        let dns_name = &self.request.host;
+        let dns_name = self.request.headers.get("Host").unwrap_or(&self.request.host);
         // parse_url in response.rs ensures that there is always a
         // ":port" in the host, which is why this unwrap is safe.
         let dns_name = dns_name.split(':').next().unwrap();

--- a/src/request.rs
+++ b/src/request.rs
@@ -73,7 +73,7 @@ pub struct Request {
     pub(crate) method: Method,
     pub(crate) host: URL,
     resource: URL,
-    headers: HashMap<String, String>,
+    pub(crate) headers: HashMap<String, String>,
     body: Option<Vec<u8>>,
     pub(crate) timeout: Option<u64>,
     max_redirects: usize,


### PR DESCRIPTION
Works fine: get->url = "https://raw.githubusercontent.com/.../master/LICENSE-APACHE"
Fails: get->url = "https://151.101.0.133/.../master/LICENSE-APACHE"
with error: IoError(Custom { kind: Other, error: InvalidDNSNameError })

Requests should respect Host entry from request headers, following changes fixed it for me.

1.inside request.rs:
 headers: HashMap<String, String>, => pub(crate) headers: HashMap<String, String>,
2.inside connection.rs:
 let dns_name = &self.request.host; => let dns_name = self.request.headers.get("Host").unwrap_or(&self.request.host);