### PR TITLE
Support redirect with relative URI-reference

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -257,9 +257,16 @@ impl Request {
 
     /// Returns the redirected version of this Request, unless an infinite redirection loop was detected.
     pub(crate) fn redirect_to(mut self, url: URL) -> Result<Request, Error> {
+        let absolute_url = if url.contains("://") {
+            url
+        } else {
+            let schema = if self.https { "https" } else { "http" };
+            format!("{}://{}{}", schema, self.host, url)
+        };
+
         self.redirects.push((self.https, self.host, self.resource));
 
-        let (https, host, resource) = parse_url(url);
+        let (https, host, resource) = parse_url(absolute_url);
         self.host = host;
         self.resource = resource;
         self.https = https;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -136,6 +136,13 @@ fn test_infinite_redirect() {
 }
 
 #[test]
+fn test_relative_redirect_get() {
+    setup();
+    let body = get_body(minreq::get(url("/relativeredirect")).with_body("Q").send());
+    assert_eq!(body, "j: Q");
+}
+
+#[test]
 fn test_head() {
     setup();
     assert_eq!(get_status_code(minreq::head(url("/b")).send()), 418);

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -89,6 +89,11 @@ pub fn setup() {
                         );
                         request.respond(response).ok();
                     }
+                    Method::Get if url == "/relativeredirect" => {
+                        let response = Response::empty(303)
+                            .with_header(Header::from_bytes(&b"Location"[..], &b"/a"[..]).unwrap());
+                        request.respond(response).ok();
+                    }
 
                     Method::Post if url == "/echo" => {
                         request.respond(Response::from_string(content)).ok();


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7231#section-7.1.2

For example, a GET request generated for the URI reference
"http://www.example.org/~tim" might result in a 303 (See Other)
response containing the header field:

  Location: /People.html#tim

which suggests that the user agent redirect to
"http://www.example.org/People.html#tim"