### PR TITLE
codebase: changed to_string to to_owned

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -131,8 +131,8 @@ impl Request {
     #[cfg(feature = "json-using-serde")]
     pub fn with_json<T: serde::ser::Serialize>(mut self, body: &T) -> Result<Request, Error> {
         self.headers.insert(
-            "Content-Type".to_string(),
-            "application/json; charset=UTF-8".to_string(),
+            "Content-Type".to_owned(),
+            "application/json; charset=UTF-8".to_owned(),
         );
         match serde_json::to_string(&body) {
             Ok(json) => Ok(self.with_body(json)),

--- a/src/response.rs
+++ b/src/response.rs
@@ -321,7 +321,7 @@ fn read_chunked(
                     }
 
                     *expecting_more_chunks = false;
-                    headers.insert("content-length".to_string(), (*content_length).to_string());
+                    headers.insert("content-length".to_owned(), (*content_length).to_string());
                     headers.remove("transfer-encoding");
                     return None;
                 }
@@ -465,7 +465,7 @@ fn parse_status_line(line: String) -> (i32, String) {
     if let Some(code) = split.nth(1) {
         if let Ok(code) = code.parse::<i32>() {
             if let Some(reason) = split.next() {
-                return (code, reason.to_string());
+                return (code, reason.to_owned());
             }
         }
     }
@@ -481,12 +481,12 @@ fn parse_header(mut line: String) -> Option<(String, String)> {
         // character after ':' was always cut off.
         let value = if let Some(sp) = line.get(location + 1..location + 2) {
             if sp == " " {
-                line[location + 2..].to_string()
+                line[location + 2..].to_owned()
             } else {
-                line[location + 1..].to_string()
+                line[location + 1..].to_owned()
             }
         } else {
-            line[location + 1..].to_string()
+            line[location + 1..].to_owned()
         };
 
         line.truncate(location);


### PR DESCRIPTION
## Reason for this PR
changed to_string to to_owned to avoid re-allocation.

Signed-off-by: karthik.n <karthik.n@zohocorp.com>