### PR TITLE
[RFC] request: included content-length=0 case as per rfc7230

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -241,6 +241,25 @@ impl Request {
         for (k, v) in &self.headers {
             http += &format!("{}: {}\r\n", k, v);
         }
+
+
+        if self.method == Method::Post || self.method == Method::Put || self.method == Method::Patch {
+            if let None = self.headers.keys().find(|key| {
+                let key = key.to_lowercase();
+                key == "content-length" || key == "transfer-encoding"
+            }) {
+                // A user agent SHOULD send a Content-Length in a request message when no Transfer-Encoding
+                // is sent and the request method defines a meaning for an enclosed payload body.
+                // refer: https://tools.ietf.org/html/rfc7230#section-3.3.2
+
+                // A client MUST NOT send a message body in a TRACE request.
+                // refer: https://tools.ietf.org/html/rfc7231#section-4.3.8
+                // similar line found for GET, HEAD, CONNECT and DELETE.
+
+                http += "Content-Length: 0\r\n";
+            }
+        }
+
         http += "\r\n";
         http
     }


### PR DESCRIPTION
## Reason
```
let resp = minreq::Request::new(minreq::Method::Post, "http://example.com").send().unwrap();
println!("{} {}", resp.status_code, resp.reason_phrase);
```
above code produces the output like below:
```
411 Length
```

This is happening because minreq not satisfied the below criteria.

> A user agent SHOULD send a Content-Length in a request message when no Transfer-Encoding is sent and the request method defines a meaning for an enclosed payload body.
> refer: https://tools.ietf.org/html/rfc7230#section-3.3.2


## Changes done

* Add `Content-Length: 0` in request header If request method sematics accepts payload body and ("content-length" or "transfer-encoding") not found in the header. (rules followed as [rfc7231](https://tools.ietf.org/rfc/rfc7231))

## Additional context

* If I read the [rfc7231](https://tools.ietf.org/rfc/rfc7231) correctly then `Trace` is the only method originated from user agent should not provide body.

> A client MUST NOT send a message body in a TRACE request.
> refer: https://tools.ietf.org/html/rfc7231#section-4.3.8

* Based on the below statement I can understand [rfc7231](https://tools.ietf.org/rfc/rfc7231) not restricted us from sending payload body in request. so, I hope `Content-Length: 0` should not cause any harm.

> 
> A payload within a CONNECT request message has no defined semantics; sending a payload body on a CONNECT request might cause some existing implementations to reject the request.
> refer: https://tools.ietf.org/html/rfc7231#section-4.3.6

* Almost all the server not supported body in `GET` but I don't find any of these enforcement in the [rfc7231](https://tools.ietf.org/rfc/rfc7231). and also I hope `content-length: 0` for `Get` is no harm.

Signed-off-by: karthik.n <karthik.n@zohocorp.com>