### PR TITLE
Track upstream rust-native-tls v0.2.6

### DIFF
--- a/src/native_tls/mod.rs
+++ b/src/native_tls/mod.rs
@@ -84,8 +84,8 @@ impl Certificate {
     }
 
     /// Parses a PEM-formatted X509 certificate.
-    pub fn from_pem(der: &[u8]) -> Result<Certificate> {
-        let cert = imp::Certificate::from_pem(der)?;
+    pub fn from_pem(pem: &[u8]) -> Result<Certificate> {
+        let cert = imp::Certificate::from_pem(pem)?;
         Ok(Certificate(cert))
     }
 
@@ -341,7 +341,7 @@ impl TlsConnectorBuilder {
 /// stream.read_to_end(&mut res).unwrap();
 /// println!("{}", String::from_utf8_lossy(&res));
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TlsConnector(imp::TlsConnector);
 
 impl TlsConnector {

--- a/src/native_tls/openssl.rs
+++ b/src/native_tls/openssl.rs
@@ -317,6 +317,18 @@ impl TlsConnector {
     }
 }
 
+impl fmt::Debug for TlsConnector {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt
+            .debug_struct("TlsConnector")
+            // n.b. SslConnector is a newtype on SslContext which implements a noop Debug so it's omitted
+            .field("use_sni", &self.use_sni)
+            .field("accept_invalid_hostnames", &self.accept_invalid_hostnames)
+            .field("accept_invalid_certs", &self.accept_invalid_certs)
+            .finish()
+    }
+}
+
 #[derive(Clone)]
 pub struct TlsAcceptor(SslAcceptor);
 


### PR DESCRIPTION
I was checking into whether any changes to rust-native-tls needed to be merged into the expanded https libraries patch from #31. There's only some variable renaming and an implementation of Debug for TlsConnector. Doesn't seem too important. But since I pulled the relevant changes into my own repo, figured might as well make a PR for them.