### PR TITLE
Bump rustls to support building on M1 Macs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { version = "^1.0.41", optional = true }
 # For the proxy feature:
 base64 = { version = "0.12", optional = true }
 # For the https features:
-rustls = { version = "^0.16.0", optional = true }
+rustls = { version = "^0.19.0", optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
 webpki-roots = { version = "^0.18.0", optional = true }
 webpki = { version = "^0.21.0", optional = true }


### PR DESCRIPTION
Ring, via rustls, fails to build on an M1 Mac. This was fixed in [ring "0.16.19"](https://github.com/briansmith/ring/issues/1163#issuecomment-750405885) - bumping the dependency chain works on my machine, and tests seem to pass - if I've missed something obvious please let me know though.