### PR TITLE
add with_params to append query params to url

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -120,6 +120,23 @@ impl Request {
         self.with_header("Content-Length", format!("{}", body_length))
     }
 
+    /// Adds given key and value as query parameter to request url (resource).
+    pub fn with_param<T: Into<String>, U: Into<String>>(mut self, key: T, value: U) ->Result<Request, Error> {
+
+        // Checks if the resource already has a query parameter 
+        // mentioned in url and if true, adds '&' to add one more 
+        // parameter or adds '?' to add the first parameter
+        if self.resource.contains("?") {
+            self.resource.push('&');
+        } else {
+            self.resource.push('?');
+        } 
+
+        self.resource.push_str(&format!("{}={}", key.into(), value.into()));
+
+        Ok(self)
+    }
+
     /// Converts given argument to JSON and sets it as body.
     ///
     /// # Errors


### PR DESCRIPTION
Added with_param() to Request

### Description 
In previous design, the query parameters are passed in the url itself when creating a request. This commit adds support for adding query parameters as key-value pairs separately using with_param() as it will improve readability. 

However, to make this backward compatible, I added a condition,  `if self.resource.contains("?")` by which it checks whether the url already has any query parameters and if true, it appends to it using `&` or creates one using `?`.


Edit [Unnecessary, removed after review by @neonmoe ]:
I also added a error variant, `QueryError` which will be thrown in case, if the resource is "/". It is safe to ignore the "" resource case, as it is handled in parse_url().
