### PR TITLE
Add https-rustls-probe feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { version = "^1.0.41", optional = true }
 base64 = { version = "0.12", optional = true }
 # For the https features:
 rustls = { version = "^0.19.0", optional = true }
+rustls-native-certs = { version = "^0.5.0", optional = true }
 lazy_static = { version = "^1.4.0", optional = true }
 webpki-roots = { version = "^0.18.0", optional = true }
 webpki = { version = "^0.21.0", optional = true }
@@ -45,6 +46,7 @@ features = ["json-using-serde", "proxy", "https", "punycode"]
 [features]
 https = ["https-rustls"]
 https-rustls = ["rustls", "lazy_static", "webpki-roots", "webpki"]
+https-rustls-probe = ["https-rustls", "rustls-native-certs"]
 https-bundled = ["openssl/vendored"]
 https-bundled-probe = ["https-bundled", "openssl-probe"]
 https-native = ["native-tls"]

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 Simple, minimal-dependency HTTP client. Optional features for json
 responses (`json-using-serde`), unicode domains (`punycode`), http
 proxies (`proxy`), and https with various TLS implementations
-(`https-rustls`, `https-bundled`, `https-bundled-probe`,
-`https-native`, and `https` which is an alias for `https-rustls`).
+(`https-rustls`, `https-rustls-probe`, `https-bundled`, 
+`https-bundled-probe`,`https-native`, and `https` which is an alias
+for `https-rustls`).
 
 Without any optional features, my casual testing indicates about 100
 KB additional executable size for stripped release builds using this

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -20,6 +20,13 @@ use webpki_roots::TLS_SERVER_ROOTS;
 lazy_static::lazy_static! {
     static ref CONFIG: Arc<ClientConfig> = {
         let mut config = ClientConfig::new();
+
+        // Try to load native certs
+        #[cfg(feature = "https-rustls-probe")]
+        if let Ok(os_roots) = rustls_native_certs::load_native_certs() {
+            config.root_store = os_roots;
+        }
+
         config
             .root_store
             .add_server_trust_anchors(&TLS_SERVER_ROOTS);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,13 @@
 //! feature variants were added, and is now an alias for
 //! `https-rustls`.
 //!
+//! ## `https-rustls-probe`
+//!
+//! Like `https-rustls`, but also includes the
+//! [`rustls-native-certs`](https://crates.io/crates/rustls-native-certs)
+//! crate to auto-detect root certificates installed in common
+//! locations.
+//!
 //! ## `https-native`
 //!
 //! Like `https`, but uses


### PR DESCRIPTION
Implements `https-rustls-probe` features which is like `https-rustls` but also includes the [`rustls-native-certs`](https://crates.io/crates/rustls-native-certs) crate to auto-detect root certificates installed in common locations.