### PR TITLE
URL encoding optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ travis-ci = { repository = "neonmoe/minreq" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
+# For the urlencoding feature:
+urlencoding = { version = "2.1.0", optional = true }
 # For the punycode feature:
 punycode = { version = "0.4.1", optional = true }
 # For the json-using-serde feature:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,12 @@
 //!
 //! This feature enables proxy support.
 //!
+//! ## `urlencoding`
+//!
+//! This feature enable resource encoding for the URL resource when
+//! creating a request and any subsequently added parameters from
+//! [`Request::with_param`].
+//!
 //! # Examples
 //!
 //! ## Get

--- a/src/request.rs
+++ b/src/request.rs
@@ -599,3 +599,28 @@ pub fn trace<T: Into<URL>>(url: T) -> Request {
 pub fn patch<T: Into<URL>>(url: T) -> Request {
     Request::new(Method::Patch, url)
 }
+
+#[cfg(all(test, feature = "urlencoding"))]
+mod encoding_tests {
+    use super::get;
+
+    #[test]
+    fn test_with_param() {
+        let req = get("http://www.example.org")
+            .with_param("foo", "bar");
+        assert_eq!(&req.resource, "/?foo=bar");
+
+        let req = get("http://www.example.org")
+            .with_param("ówò", "what's this? 👀");
+        assert_eq!(&req.resource, "/?%C3%B3w%C3%B2=what%27s%20this%3F%20%F0%9F%91%80");
+    }
+
+    #[test]
+    fn test_on_creation() {
+        let req = get("http://www.example.org/?foo=bar#baz");
+        assert_eq!(&req.resource, "/?foo=bar#baz");
+
+        let req = get("http://www.example.org/?ówò=what's this? 👀");
+        assert_eq!(&req.resource, "/?%C3%B3w%C3%B2=what%27s%20this?%20%F0%9F%91%80");
+    }
+}


### PR DESCRIPTION
Will close #67 if merged

Adds the discussed URL encoding functionality as an optional feature under `urlencoding`

The code is currently not covered by any tests. Due to the nature of the changes, I'm not able to use integration tests and I noticed the library didn't have any unit/in-module tests, so I wanted to check if you would want to include them before I wrote them. There's a fair amount of scope for arithmetic errors in the updated parser so I think it may be worthwhile

Shall add some 'code review' comments to the code to highlight notable changes