### PR TITLE
Migrate from lazy_static to once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ base64 = { version = "0.12", optional = true }
 # For the https features:
 rustls = { version = "0.20.0", optional = true }
 rustls-native-certs = { version = "0.6.1", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
+once_cell = { version = "1.14.0", optional = true }
 webpki-roots = { version = "0.22.0", optional = true }
 webpki = { version = "0.22.0", optional = true }
 openssl = { version = "0.10.29", optional = true }
@@ -47,7 +47,7 @@ features = ["json-using-serde", "proxy", "https", "punycode"]
 
 [features]
 https = ["https-rustls"]
-https-rustls = ["rustls", "lazy_static", "webpki-roots", "webpki"]
+https-rustls = ["rustls", "once_cell", "webpki-roots", "webpki"]
 https-rustls-probe = ["https-rustls", "rustls-native-certs"]
 https-bundled = ["openssl/vendored"]
 https-bundled-probe = ["https-bundled", "openssl-probe"]

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,12 +4,13 @@ use crate::proxy::Proxy;
 use crate::{Error, Response, ResponseLazy};
 use std::collections::HashMap;
 use std::fmt;
+use std::fmt::Write;
 
 /// A URL type for requests.
 pub type URL = String;
 
 /// An HTTP request method.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Method {
     /// The GET method
     Get,
@@ -85,7 +86,7 @@ impl Port {
 /// [`send`](struct.Request.html#method.send) or
 /// [`send_lazy`](struct.Request.html#method.send_lazy) on it, as it
 /// doesn't do much on its own.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Request {
     pub(crate) method: Method,
     url: URL,
@@ -341,18 +342,20 @@ impl ParsedRequest {
         let mut http = String::with_capacity(32);
 
         // Add the request line and the "Host" header
-        http += &format!(
+        write!(
+            http,
             "{} {} HTTP/1.1\r\nHost: {}",
             self.config.method, self.resource, self.host
-        );
+        )
+        .unwrap();
         if let Port::Explicit(port) = self.port {
-            http += &format!(":{}", port);
+            write!(http, ":{}", port).unwrap();
         }
         http += "\r\n";
 
         // Add other headers
         for (k, v) in &self.config.headers {
-            http += &format!("{}: {}\r\n", k, v);
+            write!(http, "{}: {}\r\n", k, v).unwrap();
         }
 
         if self.config.method == Method::Post

--- a/src/response.rs
+++ b/src/response.rs
@@ -17,7 +17,7 @@ const MAX_CONTENT_LENGTH: usize = 16 * 1024;
 /// println!("{}", response.as_str()?);
 /// # Ok(()) }
 /// ```
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Response {
     /// The status code of the response, eg. 404.
     pub status_code: i32,


### PR DESCRIPTION
Sorry, this is one of those pretentious "my choice of library is better than your choice of library" PRs. I like to think it's well justified here

---

In modern Rust code, the macro-based API of lazy_static has been superseded by the non-macro API available in once_cell:

```patch
- lazy_static! {
-     static ref FOO: Type = init(…);
- }
+ static FOO: Lazy<Type> = Lazy::new(|| init(…));
```

* Avoiding a macro where not necessary makes this code formattable by rustfmt.

* The code becomes comprehensible to rustdoc, since it is just ordinary Rust code. Hint: in the red code above, the type of FOO is not actually Type. It is a weird/unexpected struct FOO { _private: () } whose API rustdoc won't be able to show the reader.

* The non-macro API matches what is slated for standardization in the standard library: https://doc.rust-lang.org/nightly/std/cell/struct.LazyCell.html.

(explainer shamelessly stolen from [here](https://github.com/bheisler/criterion.rs/pull/611#issue-1360502421))

---

Also, fixed a few clippy lints while I was at it. Saves some allocations 😃 In a separate commit if you want to junk it