### PR TITLE
Enable building with all features

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,9 +1,10 @@
-#[cfg(feature = "openssl")]
+#[cfg(all(
+    not(feature = "rustls"),
+    any(feature = "openssl", feature = "native-tls")
+))]
 use crate::native_tls::{TlsConnector, TlsStream};
 use crate::request::ParsedRequest;
 use crate::{Error, Method, ResponseLazy};
-#[cfg(feature = "native-tls")]
-use native_tls::{TlsConnector, TlsStream};
 #[cfg(feature = "https-rustls")]
 use once_cell::sync::Lazy;
 #[cfg(feature = "rustls")]
@@ -56,7 +57,10 @@ static CONFIG: Lazy<Arc<ClientConfig>> = Lazy::new(|| {
 type UnsecuredStream = BufReader<TcpStream>;
 #[cfg(feature = "rustls")]
 type SecuredStream = StreamOwned<ClientConnection, TcpStream>;
-#[cfg(any(feature = "openssl", feature = "native-tls"))]
+#[cfg(all(
+    not(feature = "rustls"),
+    any(feature = "openssl", feature = "native-tls")
+))]
 type SecuredStream = TlsStream<TcpStream>;
 
 pub(crate) enum HttpStream {
@@ -191,7 +195,10 @@ impl Connection {
 
     /// Sends the [`Request`](struct.Request.html), consumes this
     /// connection, and returns a [`Response`](struct.Response.html).
-    #[cfg(any(feature = "openssl", feature = "native-tls"))]
+    #[cfg(all(
+        not(feature = "rustls"),
+        any(feature = "openssl", feature = "native-tls")
+    ))]
     pub(crate) fn send_https(mut self) -> Result<ResponseLazy, Error> {
         enforce_timeout(self.timeout_at, move || {
             self.request.host = ensure_ascii_host(self.request.host)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,7 @@ mod native_tls;
 #[cfg(feature = "openssl")]
 #[macro_use]
 extern crate log;
-#[cfg(feature = "native-tls")]
+#[cfg(all(feature = "native-tls", not(feature = "openssl")))]
 extern crate native_tls;
 #[cfg(feature = "openssl-probe")]
 extern crate openssl_probe;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,13 +1,13 @@
 use crate::error::Error;
 
 /// Kind of proxy connection (Basic, Digest, etc)
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub(crate) enum ProxyKind {
     Basic,
 }
 
 /// Proxy server definition
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Proxy {
     pub(crate) server: String,
     pub(crate) port: u32,


### PR DESCRIPTION
By convention a crates features should be additive, verifiable by running `cargo check --all-features`.

Modify feature gating to give an order of priority to the three different TLS features so that it is possible to enable them all.

Also add a few missing derives while we are at it.