### PR TITLE
Commit to MSRV 1.48 for current major version

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,24 @@
+name: msrv
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@1.48
+      - name: Running test script
+        run: |
+          cargo test
+          cargo test --features json-using-serde
+          cargo test --features proxy

--- a/README.md
+++ b/README.md
@@ -39,5 +39,13 @@ major version bump.
   with `http://` or `https://`.
 - Non-exhaustive error type?
 
+## Minimum Supported Rust Version (MSRV)
+
+We use an MSRV per major release, i.e., with a new major release we
+reserve the right to change the MSRV.
+
+The current major version (v2) of this library should always compile
+with any combination of features **excluding TLS** on **Rust 1.48**.
+
 ## License
 This crate is distributed under the terms of the [ISC license](COPYING.md).


### PR DESCRIPTION
In an effort to support folks that use older toolchains add a section to
the README stating that we commit to building with Rust 1.48 for the
subset of features that excludes all the TLS features. Add an additional
github action to test the MSRV. Note explicitly that this MSRV is per
major version and we reserve the right to change the MSRV when we jump
major versions.

Add a per major version Minimum Supported Rust Version (MSRV).
