### PR TITLE
Use dtonlnay instead of actions-rs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Crate
+      uses: actions/checkout@v3
+    - name: Set Toolchain
+      # https://github.com/dtolnay/rust-toolchain
+      uses: dtolnay/rust-toolchain@stable
     - name: Run rustfmt
       run: rustfmt --check src/lib.rs
     - name: Run cargo doc

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,11 @@ jobs:
   test-linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Crate
+      uses: actions/checkout@v3
+    - name: Set Toolchain
+      # https://github.com/dtolnay/rust-toolchain
+      uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build
     - name: Test
@@ -32,7 +36,10 @@ jobs:
   test-windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Crate
+      uses: actions/checkout@v3
+    - name: Set Toolchain
+      uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build
     - name: Test
@@ -47,7 +54,10 @@ jobs:
   test-macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Crate
+      uses: actions/checkout@v3
+    - name: Set Toolchain
+      uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: cargo build
     - name: Test


### PR DESCRIPTION
Currently we use the `actions-rs` GitHub action to run tests. It seems the project is now unmaintained [0].

Well known Rust developer dtonlnay maintains a GitHub action that can be used instead.

Replace all uses of `actions-rs/toolchain` with `dtonlnay/rust-toolchain`.

[0] actions-rs/toolchain#216