### PR TITLE
Add basic auth capability to Request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -169,6 +169,12 @@ impl Request {
         self
     }
 
+    /// Adds given auth string to the authorization header.
+    pub fn with_basic_auth(mut self, auth: String) -> Request {
+        self.headers.insert("Authorization".to_string(), auth);
+        self
+    }
+
     /// Converts given argument to JSON and sets it as body.
     ///
     /// # Errors


### PR DESCRIPTION
HTTP includes an authorization header, useful for example for doing authorized connection to a JSONRPC server.

### Note

I am not well versed in HTTP, I just hacked this up while attempting to use the `minreq` library to do JSONRPC calls. If there is more functionality needed please say and I'll dig more into it.

Thanks