### PR TITLE
feat: respect proxy environment variables

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -125,7 +125,11 @@ impl Request {
             max_status_line_len: None,
             max_redirects: 100,
             #[cfg(feature = "proxy")]
-            proxy: None,
+            proxy: std::env::var("MINREQ_PROXY")
+                .map_err(|_| std::env::var("HTTPS_PROXY")
+                .map_err(|_| std::env::var("HTTP_PROXY")))
+                .map(|proxy| Proxy::new(proxy).map(Some).unwrap_or(None))
+                .unwrap_or(None)
         }
     }
 


### PR DESCRIPTION
~~Try to use values from `MINREQ_PROXY` > `HTTPS_PROXY` > `HTTP_PROXY` environment variables in `Request` struct building~~

From later discussion:

- Try to use a proxy from `http_proxy`, `all_proxy` or `ALL_PROXY` if the request is HTTP
- Try to use a proxy from `https_proxy`, `HTTPS_PROXY`, `all_proxy` or `ALL_PROXY` if the request is HTTPS

From curl documentation: https://everything.curl.dev/usingcurl/proxies/env