### PR TITLE
Add `Response::is_ok` to check HTTP status code value

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -72,11 +72,14 @@ impl Response {
     /// # Example
     ///
     /// ```no_run
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let response = minreq::get("http://example.com").send()?;
     /// 
     /// if response.is_ok() {
     ///     println!("Response body: {}", response.as_str().unwrap());
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn is_ok(&self) -> bool {
         (200..299).contains(&self.status_code)

--- a/src/response.rs
+++ b/src/response.rs
@@ -65,6 +65,23 @@ impl Response {
         })
     }
 
+    /// Return true if the request's response code is in range 200-299 (HTTP OK)
+    /// 
+    /// Source: https://developer.mozilla.org/en-US/docs/Web/API/Response/ok
+    /// 
+    /// # Example
+    ///
+    /// ```no_run
+    /// let response = minreq::get("http://example.com").send()?;
+    /// 
+    /// if response.is_ok() {
+    ///     println!("Response body: {}", response.as_str().unwrap());
+    /// }
+    /// ```
+    pub fn is_ok(&self) -> bool {
+        (200..299).contains(&self.status_code)
+    }
+
     /// Returns the body as an `&str`.
     ///
     /// # Errors


### PR DESCRIPTION
Add a method to quickly check HTTP status code of the made request. It's a part of the [Fetch Standard](https://fetch.spec.whatwg.org/#ref-for-dom-response-ok%E2%91%A1) and available in any browser by default, so I think it's a good idea to add it to minreq too

Source: https://developer.mozilla.org/en-US/docs/Web/API/Response/ok

UPD: sorry for lint errors, couldn't run `cargo fmt` due to some bug in my fedora container
UPD 2: also I have a genuine question: why `status_code` is i32 instead of u32?
UPD 3: you can also rename this method to `success` because `std::process::ExitStatus` has same called method so it's kind of a Rust standard now, I suppose. But that's optional