### PR TITLE
ResponseLazy: Work in buffers, not bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minreq"
-version = "2.11.1-alpha"
+version = "3.0.0-alpha"
 authors = ["Jens Pitkanen <jens@neon.moe>"]
 description = "Simple, minimal-dependency HTTP client"
 documentation = "https://docs.rs/minreq"

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -1,0 +1,8 @@
+/// This example shows how a [`Response`] is a [`std::io::Read`],
+/// so it can be easily copied to [`std::io::write`], such as stdout
+/// or a file.
+fn main() -> Result<(), minreq::Error> {
+    let mut response = minreq::get("http://example.com").send_lazy()?;
+    std::io::copy(&mut response, &mut std::io::stdout().lock())?;
+    Ok(())
+}

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -1,23 +1,16 @@
 /// This example demonstrates probably the most complicated part of
 /// `minreq`. Useful when making loading bars, for example.
+use std::io::Read;
 
 fn main() -> Result<(), minreq::Error> {
-    let mut buffer = Vec::new();
-    for byte in minreq::get("http://example.com").send_lazy()? {
+    for byte in minreq::get("http://example.com").send_lazy()?.bytes() {
         // The connection could have a problem at any point during the
         // download, so each byte needs to be unwrapped.
-        let (byte, len) = byte?;
+        let byte = byte?;
 
         // The `byte` is the current u8 of data we're iterating
         // through.
         print!("{}", byte as char);
-
-        // The `len` is the expected amount of incoming bytes
-        // including the current one: this will be the rest of the
-        // body if the server provided a Content-Length header, or
-        // just the size of the remaining chunk in chunked transfers.
-        buffer.reserve(len);
-        buffer.push(byte);
 
         // Flush the printed text so each char appears on your
         // terminal right away.

--- a/src/request.rs
+++ b/src/request.rs
@@ -240,7 +240,11 @@ impl Request {
         self
     }
 
-    /// Sends this request to the host.
+    /// Sends this request to the host and collect the *whole* response
+    ///
+    /// **WARNING:** This does what it says on the tin — so long as the
+    /// server keeps sending bytes, they will be appended, in-memory,
+    /// to the repsonse. Consider reading from a [`ResponseLazy`] instead.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
When reading a response lazily, we want to work with it efficiently, as buffers of bytes coming out of the OS TCP stack. While we could `Iterator::collect::<Vec<u8>>()` the bytes back together from the current interface, this incurs an extra copy. (And unless optimizations can miraculously burn through all our iteration logic, we'll get an inefficient byte-by-byte copy at that!)

Instead, have ResponseLazy just implement `Read`.
Users who want individual bytes can get them with `std::io::Bytes`; that's what it's for.

While we're at it, don't lie about content-length headers that weren't actually there for a chunked transfer.

I appreciate this is an API break, but handling large downloads efficiently (and uploads for that matter; I'm thinking on a good way do that) seems like a common use case.