### PR TITLE
fix(connection): remove unnecessary `format!`

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -273,8 +273,9 @@ impl Connection {
 
     fn connect(&self) -> Result<TcpStream, Error> {
         let tcp_connect = |host: &str, port: u32| -> Result<TcpStream, Error> {
-            let host = format!("{}:{}", host, port);
-            let addrs = host.to_socket_addrs().map_err(Error::IoError)?;
+            let addrs = (host, port as u16)
+                .to_socket_addrs()
+                .map_err(Error::IoError)?;
             let addrs_count = addrs.len();
 
             // Try all resolved addresses. Return the first one to which we could connect. If all


### PR DESCRIPTION
We can use the `.to_socket_addrs()` on a `&str` and `u16` and do not need to format it to `{ip}:{port}`.

The `Connection:Connect` method currently takes up 3.6 KiB:

```
 4.2%   6.5%  3.6KiB    minreq minreq::connection::Connection::connect
```

after:

```
 2.9%   4.5%  2.4KiB    minreq minreq::connection::Connection::connect
```