### PR TITLE
Replace 'once_cell' with 'std::sync::OnceLock'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ base64 = { version = "0.12", optional = true }
 # For the https features:
 rustls = { version = "0.21.1", optional = true }
 rustls-native-certs = { version = "0.6.1", optional = true }
-once_cell = { version = "1.14.0", optional = true }
 webpki-roots = { version = "0.25.2", optional = true }
 rustls-webpki = { version = "0.101.0", optional = true }
 openssl = { version = "0.10.29", optional = true }
@@ -45,9 +44,10 @@ chrono = "0.4.0"
 features = ["json-using-serde", "proxy", "https", "punycode"]
 
 [features]
+default = ["https", "rustls"]
 https = ["https-rustls"]
-https-rustls = ["rustls", "once_cell", "webpki-roots", "rustls-webpki"]
-https-rustls-probe = ["rustls", "once_cell", "rustls-native-certs"]
+https-rustls = ["rustls", "webpki-roots", "rustls-webpki"]
+https-rustls-probe = ["rustls", "rustls-native-certs"]
 https-bundled = ["openssl/vendored"]
 https-bundled-probe = ["https-bundled", "openssl-probe"]
 https-native = ["native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ chrono = "0.4.0"
 features = ["json-using-serde", "proxy", "https", "punycode"]
 
 [features]
-default = ["https", "rustls"]
 https = ["https-rustls"]
 https-rustls = ["rustls", "webpki-roots", "rustls-webpki"]
 https-rustls-probe = ["rustls", "rustls-native-certs"]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -41,7 +41,7 @@ static CONFIG: std::sync::LazyLock<Arc<ClientConfig>> = std::sync::LazyLock::new
             ta.name_constraints,
         )
     }));
-
+    
     let config = ClientConfig::builder()
         .with_safe_defaults()
         .with_root_certificates(root_certificates)
@@ -183,7 +183,7 @@ impl Connection {
             log::trace!("Writing HTTPS request to {}.", self.request.url.host);
             let _ = tls.get_ref().set_write_timeout(self.timeout()?);
             tls.write_all(&bytes)?;
-            
+
             // Receive request
             log::trace!("Reading HTTPS response from {}.", self.request.url.host);
             let response = ResponseLazy::from_stream(

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -41,7 +41,7 @@ static CONFIG: std::sync::LazyLock<Arc<ClientConfig>> = std::sync::LazyLock::new
             ta.name_constraints,
         )
     }));
-    
+
     let config = ClientConfig::builder()
         .with_safe_defaults()
         .with_root_certificates(root_certificates)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -5,8 +5,6 @@
 use crate::native_tls::{TlsConnector, TlsStream};
 use crate::request::ParsedRequest;
 use crate::{Error, Method, ResponseLazy};
-#[cfg(feature = "once_cell")]
-use once_cell::sync::Lazy;
 #[cfg(feature = "rustls")]
 use rustls::{self, ClientConfig, ClientConnection, RootCertStore, ServerName, StreamOwned};
 #[cfg(feature = "rustls")]
@@ -21,7 +19,7 @@ use std::time::{Duration, Instant};
 use webpki_roots::TLS_SERVER_ROOTS;
 
 #[cfg(feature = "rustls")]
-static CONFIG: Lazy<Arc<ClientConfig>> = Lazy::new(|| {
+static CONFIG: std::sync::LazyLock<Arc<ClientConfig>> = std::sync::LazyLock::new(|| {
     let mut root_certificates = RootCertStore::empty();
 
     // Try to load native certs
@@ -185,7 +183,7 @@ impl Connection {
             log::trace!("Writing HTTPS request to {}.", self.request.url.host);
             let _ = tls.get_ref().set_write_timeout(self.timeout()?);
             tls.write_all(&bytes)?;
-
+            
             // Receive request
             log::trace!("Reading HTTPS response from {}.", self.request.url.host);
             let response = ResponseLazy::from_stream(


### PR DESCRIPTION
In version 1.80.0 Rust added `OnceCell` and `LazyCell`, which work in the same way as the `once_cell` structs, making the dependency unnecessary.